### PR TITLE
Editor and snippet line display instances of CodeMirror have their own respective heights

### DIFF
--- a/src/components/AnnotationCreator.jsx
+++ b/src/components/AnnotationCreator.jsx
@@ -1,16 +1,9 @@
 import React, { PropTypes } from 'react';
-import CodeMirror from 'react-codemirror';
 
 import RaisedButton from 'material-ui/RaisedButton';
 import TextField from 'material-ui/TextField';
 
-// Base options for CodeMirror instances for an AnnotationDisplay
-const baseOptions = {
-  lineNumbers: true,
-  theme: 'codesplain',
-  readOnly: true,
-  cursorBlinkRate: -1,
-};
+import LineSnippet from './LineSnippet';
 
 class AnnotationCreator extends React.Component {
   constructor(props) {
@@ -41,18 +34,12 @@ class AnnotationCreator extends React.Component {
   }
 
   render() {
-    const codeMirrorOptions = {
-      ...baseOptions,
-      firstLineNumber: this.props.lineNumber + 1,
-    }
+
     return (
       <div>
-        <CodeMirror
-          style={{
-            height: 'auto',
-          }}
+        <LineSnippet
+          lineNumber={this.props.lineNumber + 1}
           value={this.props.lineText}
-          options={codeMirrorOptions}
         />
         <TextField
           name="annotationEditor"

--- a/src/components/AnnotationDisplay.jsx
+++ b/src/components/AnnotationDisplay.jsx
@@ -1,29 +1,15 @@
 import React, { PropTypes } from 'react';
-import CodeMirror from 'react-codemirror';
 
 import RaisedButton from 'material-ui/RaisedButton';
 
-// Base options for CodeMirror instances for an AnnotationDisplay
-const baseOptions = {
-  lineNumbers: true,
-  theme: 'codesplain',
-  readOnly: true,
-  cursorBlinkRate: -1,
-};
+import LineSnippet from './LineSnippet';
 
 const AnnotationDisplay = ({ closeAnnotation, lineNumber, lineText, snippetLanugage, text }) => {
-  const codeMirrorOptions = {
-    ...baseOptions,
-    firstLineNumber: lineNumber + 1,
-  }
   return (
     <div>
-      <CodeMirror
-        style={{
-          height: 'auto',
-        }}
+      <LineSnippet
+        lineNumber={lineNumber + 1}
         value={lineText}
-        options={codeMirrorOptions}
       />
       <pre>{text}</pre>
       <RaisedButton

--- a/src/components/LineSnippet.jsx
+++ b/src/components/LineSnippet.jsx
@@ -1,0 +1,37 @@
+import React, { PropTypes } from 'react';
+import CodeMirror from 'react-codemirror';
+
+// Base options for CodeMirror instances for an AnnotationDisplay
+const baseOptions = {
+  lineNumbers: true,
+  theme: 'codesplain',
+  readOnly: true,
+  cursorBlinkRate: -1,
+};
+
+class LineSnippet extends React.Component {
+  componentDidMount() {
+    const cm = this.codeMirror.getCodeMirror();
+    cm.setSize('auto', 'auto');
+  }
+  render() {
+    const codeMirrorOptions = {
+      ...baseOptions,
+      firstLineNumber: this.props.lineNumber,
+    };
+    return (
+      <CodeMirror
+        ref={cm => { this.codeMirror = cm; }}
+        value={this.props.value}
+        options={codeMirrorOptions}
+      />
+    );
+  }
+}
+
+LineSnippet.propTypes = {
+  value: PropTypes.string.isRequired,
+  lineNumber: PropTypes.number.isRequired,
+};
+
+export default LineSnippet;

--- a/src/styles/codesplain.css
+++ b/src/styles/codesplain.css
@@ -4,7 +4,3 @@
   padding-top: 2px;
   padding-bottom: 2px;
 }
-
-.CodeMirror {
-  height: auto;
-}


### PR DESCRIPTION
Each of these components have their respective heights; editor will be expanded, whereas the snippet line displays are compact and resize to fit their contents