### PR TITLE
Fixed by switching from preformatted block to paragraph block with monospaced font

### DIFF
--- a/src/components/AnnotationDisplay.jsx
+++ b/src/components/AnnotationDisplay.jsx
@@ -4,6 +4,10 @@ import RaisedButton from 'material-ui/RaisedButton';
 
 import LineSnippet from './LineSnippet';
 
+const style = {
+  fontFamily: 'monospace'
+}
+
 const AnnotationDisplay = ({ closeAnnotation, lineNumber, lineText, snippetLanugage, text }) => {
   return (
     <div>
@@ -11,7 +15,7 @@ const AnnotationDisplay = ({ closeAnnotation, lineNumber, lineText, snippetLanug
         lineNumber={lineNumber + 1}
         value={lineText}
       />
-      <pre>{text}</pre>
+      <p style={style}>{text}</p>
       <RaisedButton
         label="Close"
         secondary


### PR DESCRIPTION
closes #81
<img width="400" alt="screen shot 2017-03-02 at 10 15 48 am" src="https://cloud.githubusercontent.com/assets/10768827/23515911/435a4130-ff31-11e6-9de1-65c51e2e57a9.png">
