### PR TITLE
Fixed by adding additional css to preserve newlines and scroll inline overflow

### DIFF
--- a/src/components/AnnotationDisplay.jsx
+++ b/src/components/AnnotationDisplay.jsx
@@ -5,7 +5,9 @@ import RaisedButton from 'material-ui/RaisedButton';
 import LineSnippet from './LineSnippet';
 
 const style = {
-  fontFamily: 'monospace'
+  fontFamily: 'monospace',
+  whiteSpace: 'pre-wrap',
+  overflow: 'scroll'
 }
 
 const AnnotationDisplay = ({ closeAnnotation, lineNumber, lineText, snippetLanugage, text }) => {


### PR DESCRIPTION
Closes #90
<img width="407" alt="screen shot 2017-03-02 at 11 20 49 am" src="https://cloud.githubusercontent.com/assets/10768827/23518826/51c6be34-ff3a-11e6-8b3c-2397cc0da9e2.png">
