### PR TITLE
Made header clickable

### DIFF
--- a/src/components/CodesplainAppBar.jsx
+++ b/src/components/CodesplainAppBar.jsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import AppBar from 'material-ui/AppBar';
+import { browserHistory } from 'react-router';
+
+const styles = {
+  title: {
+    cursor: 'pointer',
+  }
+}
 
 /**
  * A simple example of `AppBar` with an icon on the right.
@@ -9,6 +16,11 @@ const CodesplainAppBar = () => (
   <AppBar
     showMenuIconButton={false}
     title="Codesplain"
+    style={styles.title}
+    onTitleTouchTap={() => { 
+      browserHistory.push('/'); 
+      location.reload();
+    }}
   />
 );
 


### PR DESCRIPTION
Fixes #68. The "Codesplain" header can now be clicked to navigate to the "home" page and create a new snippet.