### PR TITLE
Fixed issue with saving JSON objects to Redis

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -44,7 +44,7 @@ app.post('/api/snippets/', function(req, res) {
   var id = uuid();
   var json = JSON.parse(req.body.json);
   if (_.isObject(json) && _.congruent(requestTemplate, json)) {
-    redis.set(id, json);
+    redis.set(id, JSON.stringify(json));
     res.json({id: id});
   } else {
     res.status(400).send('Invalid POST request body');


### PR DESCRIPTION
Fixes an issue with my [previous PR](https://github.com/maryvilledev/codesplainUI/pull/140) that will save a JS object to Redis instead of a JSON string representation