### PR TITLE
Show Lock Button Tool Tip When Disabled

### DIFF
--- a/__tests__/components/__snapshots__/LockButton.test.jsx.snap
+++ b/__tests__/components/__snapshots__/LockButton.test.jsx.snap
@@ -1,37 +1,39 @@
 exports[`<LockButton /> matches snapshot of when the app is in read-only mode 1`] = `
-<IconButton
-  disableTouchRipple={false}
-  disabled={true}
-  iconStyle={Object {}}
-  label="Switch to edit mode"
-  onTouchTap={[Function]}
-  style={
-    Object {
-      "zIndex": 5,
+<div
+  title="Switching back to edit mode not supported yet">
+  <IconButton
+    disableTouchRipple={false}
+    disabled={true}
+    iconStyle={Object {}}
+    label="Switch to edit mode"
+    style={
+      Object {
+        "zIndex": 5,
+      }
     }
-  }
-  tooltip="Switching back to edit mode not supported yet"
-  tooltipPosition="bottom-center"
-  touch={false}>
-  <ActionLock />
-</IconButton>
+    tooltipPosition="bottom-center"
+    touch={false}>
+    <ActionLock />
+  </IconButton>
+</div>
 `;
 
 exports[`<LockButton /> matches snapshot of when the app is not in read-only mode 1`] = `
-<IconButton
-  disableTouchRipple={false}
-  disabled={false}
-  iconStyle={Object {}}
-  label="Switch to read-only mode"
-  onTouchTap={[Function]}
-  style={
-    Object {
-      "zIndex": 5,
+<div
+  title="Click to lock the snippet (this will prevent further changes.)">
+  <IconButton
+    disableTouchRipple={false}
+    disabled={false}
+    iconStyle={Object {}}
+    label="Switch to read-only mode"
+    style={
+      Object {
+        "zIndex": 5,
+      }
     }
-  }
-  tooltip="Click to lock the snippet (this will prevent further changes.)"
-  tooltipPosition="bottom-center"
-  touch={false}>
-  <ActionLockOpen />
-</IconButton>
+    tooltipPosition="bottom-center"
+    touch={false}>
+    <ActionLockOpen />
+  </IconButton>
+</div>
 `;

--- a/src/components/buttons/LockButton.jsx
+++ b/src/components/buttons/LockButton.jsx
@@ -12,15 +12,17 @@ const LockButton = ({ onClick, readOnly }) => {
   const lockIcon = readOnly ? <Lock /> : <LockOpen />;
   const toolTipText = readOnly ? 'Switching back to edit mode not supported yet' : 'Click to lock the snippet (this will prevent further changes.)';
   return (
-    <IconButton
-      disabled={readOnly}
-      label={`Switch to ${readOnly ? 'edit' : 'read-only'} mode`}
-      onTouchTap={onClick}
-      tooltip={toolTipText}
-      style={style}
+    <div 
+      title={toolTipText}
     >
-      {lockIcon}
-    </IconButton>
+      <IconButton
+        disabled={readOnly}
+        label={`Switch to ${readOnly ? 'edit' : 'read-only'} mode`}
+        style={style}
+      >
+        {lockIcon}
+      </IconButton>
+    </div>
   );
 };
 


### PR DESCRIPTION
Fixes #95. Moved tooltip from button to a surrounding div, so it now displays even when the button is locked.

## Div Tooltips
![screen shot 2017-03-14 at 2 39 35 pm](https://cloud.githubusercontent.com/assets/10351828/23919286/50817314-08c4-11e7-9b18-9c71782c3da9.png)
![screen shot 2017-03-14 at 2 39 45 pm](https://cloud.githubusercontent.com/assets/10351828/23919285/507ca532-08c4-11e7-9ced-018945e5022a.png)

## Material UI Tooltip
![screen shot 2017-03-14 at 2 39 49 pm](https://cloud.githubusercontent.com/assets/10351828/23919287/50826d46-08c4-11e7-88d6-cae179509e05.png)
