### PR TITLE
Add syntax highlighting to code blocks in MarkdownRenderer

### DIFF
--- a/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
@@ -1,7 +1,13 @@
 exports[`<AnnotationDisplay /> matches snapshot 1`] = `
 <div>
   <MarkdownRenderer
-    markdown="some annotation" />
+    markdown="some annotation"
+    options={
+      Object {
+        "highlight": [Function],
+        "langPrefix": "hljs language-",
+      }
+    } />
   <RaisedButton
     disabled={false}
     fullWidth={false}

--- a/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
@@ -24,7 +24,13 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
     <Tab
       label="Preview">
       <MarkdownRenderer
-        markdown="" />
+        markdown=""
+        options={
+          Object {
+            "highlight": [Function],
+            "langPrefix": "hljs language-",
+          }
+        } />
     </Tab>
   </Tabs>
   <RaisedButton

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "enzyme": "^2.7.1",
     "enzyme-to-json": "^1.5.0",
     "express": "^4.14.1",
+    "highlight.js": "^9.10.0",
     "ioredis": "^2.5.0",
     "lodash": "^4.17.4",
     "material-ui": "^0.17.1",

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/styles/default.min.css">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
 
     <!--

--- a/src/components/AnnotationDisplay.jsx
+++ b/src/components/AnnotationDisplay.jsx
@@ -2,6 +2,8 @@ import React, { PropTypes } from 'react';
 import MarkdownRenderer from 'react-markdown-renderer';
 import RaisedButton from 'material-ui/RaisedButton';
 
+import markdownRendererOptions from '../util/markdown-renderer-options';
+
 const AnnotationDisplay = (props) => {
   const {
     annotation,
@@ -13,6 +15,7 @@ const AnnotationDisplay = (props) => {
     <div>
       <MarkdownRenderer
         markdown={annotation}
+        options={markdownRendererOptions}
       />
       <RaisedButton
         label="Close"

--- a/src/components/AnnotationEditor.jsx
+++ b/src/components/AnnotationEditor.jsx
@@ -4,6 +4,8 @@ import { Tab, Tabs } from 'material-ui/Tabs';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 
+import markdownRendererOptions from '../util/markdown-renderer-options';
+
 class AnnotationEditor extends React.Component {
   constructor(props) {
     super(props);
@@ -55,6 +57,7 @@ class AnnotationEditor extends React.Component {
           <Tab label="Preview">
             <MarkdownRenderer
               markdown={this.state.annotation}
+              options={markdownRendererOptions}
             />
           </Tab>
         </Tabs>

--- a/src/util/markdown-renderer-options.js
+++ b/src/util/markdown-renderer-options.js
@@ -3,17 +3,13 @@ import hljs from 'highlight.js';
 export default {
   langPrefix: 'hljs language-',
   highlight: function (str, lang) {
-    if (lang && hljs.getLanguage(lang)) {
-      try {
-        console.log('foo');
-        return hljs.highlight(lang, str).value;
-      } catch (err) {}
-    }
-    console.log('bar');
     try {
+      if (lang && hljs.getLanguage(lang)) {
+        return hljs.highlight(lang, str).value;
+      }
       return hljs.highlightAuto(str).value;
     } catch (err) {}
-    console.log('baz');
+
     return ''; // use external default escaping
   }
 }

--- a/src/util/markdown-renderer-options.js
+++ b/src/util/markdown-renderer-options.js
@@ -1,0 +1,19 @@
+import hljs from 'highlight.js';
+
+export default {
+  langPrefix: 'hljs language-',
+  highlight: function (str, lang) {
+    if (lang && hljs.getLanguage(lang)) {
+      try {
+        console.log('foo');
+        return hljs.highlight(lang, str).value;
+      } catch (err) {}
+    }
+    console.log('bar');
+    try {
+      return hljs.highlightAuto(str).value;
+    } catch (err) {}
+    console.log('baz');
+    return ''; // use external default escaping
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2572,6 +2572,10 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+highlight.js@^9.10.0:
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.10.0.tgz#f9f0b14c0be00f0e4fb1e577b749fed9e6f52f55"
+
 history@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-3.3.0.tgz#fcedcce8f12975371545d735461033579a6dae9c"


### PR DESCRIPTION
Fixes #227

Adds syntax highlighting to code blocks in the `MarkdownRenderer` for the `AnnotationDisplay` and `AnnotationEditor` components. 

Possible improvements would be to [run the highlighting function in a web worker](https://github.com/isagalaev/highlight.js)