### PR TITLE
Add indicator of Markdown support in AnnotationEditor

### DIFF
--- a/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
@@ -53,7 +53,7 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
     href="http://commonmark.org/help"
     style={
       Object {
-        "padding-left": "1rem",
+        "paddingLeft": "1rem",
       }
     }
     target="_blank">

--- a/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
@@ -49,5 +49,31 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
     onTouchTap={[Function]}
     primary={true}
     secondary={false} />
+  <a
+    href="http://commonmark.org/help"
+    style={
+      Object {
+        "padding-left": "1rem",
+      }
+    }
+    target="_blank">
+    <img
+      alt="Markdown Logo"
+      src="markdown-logo.svg"
+      style={
+        Object {
+          "height": "1rem",
+          "width": "2rem",
+        }
+      } />
+    <span
+      style={
+        Object {
+          "color": "#d3d3d3",
+        }
+      }>
+      Styling with Markdown is supported
+    </span>
+  </a>
 </div>
 `;

--- a/res/markdown-logo.svg
+++ b/res/markdown-logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="208" height="128" viewBox="0 0 208 128"><rect width="198" height="118" x="5" y="5" ry="10" stroke="#000" stroke-width="10" fill="none"/><path d="M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z"/></svg>

--- a/src/components/AnnotationEditor.jsx
+++ b/src/components/AnnotationEditor.jsx
@@ -8,13 +8,13 @@ import markdownRendererOptions from '../util/markdown-renderer-options';
 import markdownLogo from '../../res/markdown-logo.svg';
 
 const styles = {
-  'markdown-hint-text': {
+  'markdownHintText': {
     'color': '#d3d3d3',
   },
-  'markdown-indicator': {
+  'markdownIndicator': {
     'padding-left': '1rem',
   },
-  'markdown-logo': {
+  'markdownLogo': {
     width: '2rem',
     height: '1rem',
   },
@@ -88,16 +88,16 @@ class AnnotationEditor extends React.Component {
         />
         <a
           href="http://commonmark.org/help"
-          style={styles['markdown-indicator']}
+          style={styles.markdownIndicator}
           target="_blank"
         >
           <img
             alt="Markdown Logo"
             src={markdownLogo}
-            style={styles['markdown-logo']}
+            style={styles.markdownLogo}
           />
           <span
-            style={styles['markdown-hint-text']}
+            style={styles.markdownHintText}
           >
             Styling with Markdown is supported
           </span>

--- a/src/components/AnnotationEditor.jsx
+++ b/src/components/AnnotationEditor.jsx
@@ -12,7 +12,7 @@ const styles = {
     'color': '#d3d3d3',
   },
   'markdownIndicator': {
-    'padding-left': '1rem',
+    'paddingLeft': '1rem',
   },
   'markdownLogo': {
     width: '2rem',

--- a/src/components/AnnotationEditor.jsx
+++ b/src/components/AnnotationEditor.jsx
@@ -5,6 +5,20 @@ import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 
 import markdownRendererOptions from '../util/markdown-renderer-options';
+import markdownLogo from '../../res/markdown-logo.svg';
+
+const styles = {
+  'markdown-hint-text': {
+    'color': '#d3d3d3',
+  },
+  'markdown-indicator': {
+    'padding-left': '1rem',
+  },
+  'markdown-logo': {
+    width: '2rem',
+    height: '1rem',
+  },
+}
 
 class AnnotationEditor extends React.Component {
   constructor(props) {
@@ -43,11 +57,11 @@ class AnnotationEditor extends React.Component {
           >
             <TextField
               autoFocus
-              name="annotationEditor"
               floatingLabelText="Annotation"
               fullWidth
               hintText="Enter your annotation here"
               multiLine
+              name="annotationEditor"
               onChange={this.onAnnotationChange}
               ref={(textField) => { this.textField = textField; }}
               rows={4}
@@ -63,15 +77,31 @@ class AnnotationEditor extends React.Component {
         </Tabs>
         <RaisedButton
           label="Cancel"
-          secondary
           onTouchTap={this.clearAnnotation}
+          secondary
         />
         <RaisedButton
-          label="Save"
-          primary
           disabled={!this.state.annotation}
+          label="Save"
           onTouchTap={this.saveAnnotation}
+          primary
         />
+        <a
+          href="http://commonmark.org/help"
+          style={styles['markdown-indicator']}
+          target="_blank"
+        >
+          <img
+            alt="Markdown Logo"
+            src={markdownLogo}
+            style={styles['markdown-logo']}
+          />
+          <span
+            style={styles['markdown-hint-text']}
+          >
+            Styling with Markdown is supported
+          </span>
+        </a>
       </div>
     );
   }


### PR DESCRIPTION
Fixes #139 

Adds a Markdown logo and indicator that Markdown is supported in the AnnotationEditor