### PR TITLE
Refactor FilterArea

### DIFF
--- a/__tests__/components/FilterAreaActions.test.jsx
+++ b/__tests__/components/FilterAreaActions.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+import FilterAreaActions from '../../src/components/FilterAreaActions';
+
+describe('<FilterAreaActions />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = (node) => shallow(node, { context: { muiTheme } });
+
+  it('matches snapshot of when the app is not in read-only mode', () => {
+    const wrapper = shallowWithContext(
+      <FilterAreaActions
+        clearAll={jest.fn()}
+        selectAll={jest.fn()}
+      />
+    );
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+
+  describe('prop: clearAll', () => {
+    it('is triggered when "Clear All" button is clicked', () => {
+      const clearAll = jest.fn();
+      const wrapper = shallowWithContext(
+        <FilterAreaActions
+          clearAll={clearAll}
+          selectAll={jest.fn()}
+        />
+      );
+      const button = wrapper.find('FlatButton[label="Clear All"]');
+      button.simulate('touchTap');
+      expect(clearAll).toHaveBeenCalled();
+    });
+  });
+  describe('prop: selectAll', () => {
+    it('is triggered when "Select All" button is clicked', () => {
+      const selectAll = jest.fn();
+      const wrapper = shallowWithContext(
+        <FilterAreaActions
+          clearAll={jest.fn()}
+          selectAll={selectAll}
+        />
+      );
+      const button = wrapper.find('FlatButton[label="Select All"]');
+      button.simulate('touchTap');
+      expect(selectAll).toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/components/__snapshots__/FilterAreaActions.test.jsx.snap
+++ b/__tests__/components/__snapshots__/FilterAreaActions.test.jsx.snap
@@ -1,0 +1,38 @@
+exports[`<FilterAreaActions /> matches snapshot of when the app is not in read-only mode 1`] = `
+<CardActions>
+  <FlatButton
+    disabled={false}
+    fullWidth={true}
+    label="Select All"
+    labelPosition="after"
+    labelStyle={
+      Object {
+        "fontSize": "12px",
+      }
+    }
+    onKeyboardFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onTouchStart={[Function]}
+    onTouchTap={[Function]}
+    primary={true}
+    secondary={false} />
+  <FlatButton
+    disabled={false}
+    fullWidth={true}
+    label="Clear All"
+    labelPosition="after"
+    labelStyle={
+      Object {
+        "fontSize": "12px",
+      }
+    }
+    onKeyboardFocus={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onTouchStart={[Function]}
+    onTouchTap={[Function]}
+    primary={false}
+    secondary={true} />
+</CardActions>
+`;

--- a/__tests__/components/__snapshots__/RulesSelector.test.jsx.snap
+++ b/__tests__/components/__snapshots__/RulesSelector.test.jsx.snap
@@ -1,26 +1,14 @@
 exports[`<RulesSelector /> matches snapshot 1`] = `
 <div>
-  <Subheader
-    inset={false}
-    style={
-      Object {
-        "lineHeight": 1,
-        "padding": 0,
-      }
-    }>
-    Select a token type to highlight all occurences
-  </Subheader>
-  <div>
-    <RuleLabel
-      count={1}
-      isActive={false}
-      onClick={[Function]}
-      rule="For Loops" />
-    <RuleLabel
-      count={21}
-      isActive={true}
-      onClick={[Function]}
-      rule="Atoms" />
-  </div>
+  <RuleLabel
+    count={1}
+    isActive={false}
+    onClick={[Function]}
+    rule="For Loops" />
+  <RuleLabel
+    count={21}
+    isActive={true}
+    onClick={[Function]}
+    rule="Atoms" />
 </div>
 `;

--- a/src/components/FilterAreaActions.jsx
+++ b/src/components/FilterAreaActions.jsx
@@ -1,0 +1,37 @@
+import React, { PropTypes } from 'react';
+import {
+  CardActions,
+  FlatButton,
+} from 'material-ui';
+
+const styles = {
+  label: {
+    fontSize: '12px',
+  },
+}
+
+const FilterAreaActions = ({clearAll, selectAll}) => (
+  <CardActions>
+    <FlatButton
+      fullWidth
+      label="Select All"
+      labelStyle={styles.label}
+      onTouchTap={selectAll}
+      primary
+    />
+    <FlatButton
+      fullWidth
+      label="Clear All"
+      labelStyle={styles.label}
+      onTouchTap={clearAll}
+      secondary
+    />
+  </CardActions>
+);
+
+FilterAreaActions.propTypes = {
+  clearAll: PropTypes.func.isRequired,
+  selectAll: PropTypes.func.isRequired,
+};
+
+export default FilterAreaActions;

--- a/src/components/RulesSelector.jsx
+++ b/src/components/RulesSelector.jsx
@@ -1,13 +1,5 @@
 import React, { PropTypes } from 'react';
 import RuleLabel from './RuleLabel';
-import { Subheader } from 'material-ui';
-
-const styles = {
-  subheader: {
-    lineHeight: 1,
-    padding: 0,
-  },
-}
 
 const makeListItems = (filters, onRuleSelected) => {
   return Object.keys(filters)

--- a/src/components/RulesSelector.jsx
+++ b/src/components/RulesSelector.jsx
@@ -36,12 +36,7 @@ const RulesSelector = ({ filters, onRuleSelected }) => {
   const listItems = makeListItems(filters, onRuleSelected);
   return (
     <div>
-      <Subheader style={styles.subheader}>
-        Select a token type to highlight all occurences
-      </Subheader>
-      <div>
-        {listItems}
-      </div>
+      {listItems}
     </div>
   );
 };

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -67,7 +67,7 @@ export class AppBody extends React.Component {
       <div className='container-fluid'>
         <div className='row'>
           <div className='col-lg-2'>
-            <Card><FilterArea /></Card>
+            <FilterArea />
           </div>
           <div
             className='col-lg-5 col-md-7'

--- a/src/containers/FilterArea.jsx
+++ b/src/containers/FilterArea.jsx
@@ -2,11 +2,12 @@ import React from 'react'
 import { connect } from 'react-redux'
 import _ from 'lodash'
 import {
+  Card,
   CardText,
-  Divider,
-  RaisedButton,
+  CardTitle,
 } from 'material-ui';
 
+import FilterAreaActions from '../components/FilterAreaActions';
 import RulesSelector from '../components/RulesSelector';
 
 import {
@@ -14,10 +15,6 @@ import {
   selectAllFilters,
   setRuleFilters
 } from '../actions/app';
-
-const labelStyle = {
-  fontSize: '12px',
-};
 
 const toggleFilter = (filters, filterName) => {
   filters[filterName].selected = !filters[filterName].selected
@@ -27,7 +24,7 @@ export class FilterArea extends React.Component {
   constructor(props) {
     super(props)
     this.handleRuleSelected = this.handleRuleSelected.bind(this);
-    this.handleResetFilters = this.handleResetFilters.bind(this);;
+    this.handleClearAllFilters = this.handleClearAllFilters.bind(this);;
     this.handleSelectAllFilters = this.handleSelectAllFilters.bind(this);
   }
   handleRuleSelected(filterName) {
@@ -36,7 +33,7 @@ export class FilterArea extends React.Component {
     toggleFilter(newFilters, filterName)
     dispatch(setRuleFilters(newFilters))
   }
-  handleResetFilters() {
+  handleClearAllFilters() {
     const { dispatch } = this.props;
     dispatch(resetFilters());
   }
@@ -46,28 +43,22 @@ export class FilterArea extends React.Component {
   }
   render() {
     const { filters } = this.props;
+    const filterAreaActions = Object.keys(filters).length ?
+      <FilterAreaActions
+        clearAll={this.handleClearAllFilters}
+        selectAll={this.handleSelectAllFilters}
+      /> : null;
     return (
-      <CardText>
-        <RulesSelector
-          filters={filters}
-          onRuleSelected={this.handleRuleSelected}
-        />
-        <br /><Divider /><br />
-        <RaisedButton
-          fullWidth
-          label="Select All"
-          labelStyle={labelStyle}
-          onTouchTap={this.handleSelectAllFilters}
-          primary
-        />
-        <RaisedButton
-          fullWidth
-          label="Reset"
-          labelStyle={labelStyle}
-          onTouchTap={this.handleResetFilters}
-          secondary
-        />
-      </CardText>
+      <Card>
+        <CardTitle title="Filters" />
+        <CardText>
+          <RulesSelector
+            filters={filters}
+            onRuleSelected={this.handleRuleSelected}
+          />
+        </CardText>
+        { filterAreaActions }
+      </Card>
     );
   }
 }


### PR DESCRIPTION
Fixes #301 

Makes  some lovely changes to the FilterArea

No filters to select:
<img width="1670" alt="screen shot 2017-03-30 at 2 03 15 pm" src="https://cloud.githubusercontent.com/assets/10211603/24521420/bb5fa7d4-1551-11e7-8e8b-68871937040e.png">

Filters selectable:
<img width="977" alt="screen shot 2017-03-30 at 2 03 30 pm" src="https://cloud.githubusercontent.com/assets/10211603/24521422/bf53c532-1551-11e7-89c2-31f7726f598a.png">

