### PR TITLE
Fix bug that flags users having unsaved changes when loading a snippet

### DIFF
--- a/__tests__/reducers/app.js
+++ b/__tests__/reducers/app.js
@@ -190,7 +190,11 @@ describe('Reducer: App', () => {
       type: actions.RESTORE_STATE,
       payload: savedState
     };
-    expect(reducer(undefined, action)).toEqual(savedState);
+    const expected = {
+      ...savedState,
+      hasUnsavedChanges: false,
+    };
+    expect(reducer(undefined, action)).toEqual(expected);
   });
   it('should handle SET_SNIPPET_TITLE', () => {
     const snippetTitle = 'Get Schwifty'

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -80,7 +80,10 @@ const app = (state = initialState, action) => {
       };
     }
     case actions.RESTORE_STATE: {
-      return action.payload
+      return {
+        ...action.payload,
+        hasUnsavedChanges: false,
+      };
     }
     case actions.SET_SNIPPET_TITLE: {
       return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Edits the `app` reducer to set `hasUnsavedChanges` to false when reloading a snippet

## Motivation and Context
Fixes #346 

Necessary because users will be asked if they wish to navigate away even though they haven't made any changes, which is a minor annoyance

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.