### PR TITLE
Shows a different error message based upon the reason for login rejection

### DIFF
--- a/__tests__/components/Auth.test.jsx
+++ b/__tests__/components/Auth.test.jsx
@@ -1,13 +1,23 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { shallowToJson } from 'enzyme-to-json';
+import { shallow, mount } from 'enzyme';
+import toJson, { shallowToJson } from 'enzyme-to-json';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import moxios from 'moxios'
+import injectTapEventPlugin from 'react-tap-event-plugin';
+// Needed for onTouchTap
+// http://stackoverflow.com/a/34015469/988941
+injectTapEventPlugin();
 
-import Auth from '../../src/components/Auth';
+import Auth, { errors } from '../../src/components/Auth';
+import Alert from '../../src/components/Alert';
 
 describe('<Auth />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, { context: { muiTheme } });
+  const mountWithContext = (node) => mount(node, {
+    context: { muiTheme },
+    childContextTypes: { muiTheme: React.PropTypes.object }
+   });
 
   it('matches snapshot', () => {
     const wrapper = shallowWithContext(
@@ -15,4 +25,50 @@ describe('<Auth />', () => {
     );
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
+
+  describe('login responses', () => {
+    beforeEach(() => {
+      moxios.install();
+    })
+    afterEach(() => {
+      moxios.uninstall();
+    })
+
+    it('should respond to a 400', done => {
+      const location = {query: "badcode"}
+      const wrapper = mountWithContext(
+        <Auth location={location} />
+      );
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.respondWith({
+          status: 400,
+          response: {status: '400'}
+        }).then(() => {
+          const alert = wrapper.find(Alert).first();
+          expect(alert.exists()).toBeTruthy();
+          expect(alert.props().text).toEqual(errors.badCode);
+          done();
+        });
+      });
+    })
+    it('should respond to a 403', done => {
+      const location = {query: "badcode"}
+      const wrapper = mountWithContext(
+        <Auth location={location} />
+      );
+      moxios.wait(() => {
+        const request = moxios.requests.mostRecent();
+        request.respondWith({
+          status: 403,
+          response: {status: '403'}
+        }).then(() => {
+          const alert = wrapper.find(Alert).first();
+          expect(alert.exists()).toBeTruthy();
+          expect(alert.props().text).toEqual(errors.badOrg);
+          done();
+        });
+      });
+    })
+  })
 });

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -12,6 +12,19 @@ export const errors = {
   " this application."
 }
 
+const resolveErrorMessage = (status) => {
+  switch (status) {
+    case 403: {
+      return errors.badOrg;
+    }
+    // eslint-disable-next-line
+    case 400: //Intentional fallthrough
+    default: {
+      return errors.badCode;
+    }
+  }
+}
+
 /*
 <Auth /> is the component that is rendered for the '{{url}}/auth' endpoint (which
 is the endpoint the user is sent to after signing in to GitHub). It initially
@@ -58,18 +71,7 @@ class Auth extends React.Component {
       })
       .catch( err => {
         // If this fails, we need to make sure the error dialog shows
-        let error
-        switch (err.response.status) {
-          case 403: {
-            error = errors.badOrg
-            break;
-          }
-          // eslint-disable-next-line
-          case 400: //Intentional fallthrough
-          default: {
-            error = errors.badCode;
-          }
-        }
+        const error = resolveErrorMessage(err.response.status);
         this.setState({ waiting: false, error });
       })
   }

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -6,6 +6,11 @@ import Loading from '../components/Loading';
 import Alert from '../components/Alert';
 
 const API_URL = process.env.REACT_APP_API_URL;
+const errors = {
+  badCode: "Failed to login with GitHub, sorry.",
+  badOrg: "Sorry, you are not a member of an organization authorized to use" +
+  " this application."
+}
 
 /*
 <Auth /> is the component that is rendered for the '{{url}}/auth' endpoint (which
@@ -41,7 +46,19 @@ class Auth extends React.Component {
         })
       }, err => {
         // If this fails, we need to make sure the error dialog shows
-        this.setState({ waiting: false, error: true });
+        let error
+        switch (error.response.status) {
+          case 403: {
+            error = errors.badOrg
+          }
+          // eslint-disable-next-line
+          case 400: //Intentional fallthrough
+          default: {
+            error = errors.badCode;
+            break;
+          }
+        }
+        this.setState({ waiting: false, error: error });
       })
       .then(res => {
         // Can pull lots of other stuff out of res.data if needed
@@ -78,7 +95,7 @@ class Auth extends React.Component {
       if (this.state.error) {
         return (
           <Alert
-            text="Failed to login with GitHub, sorry."
+            text={this.state.error}
             onClose={this.redirectUser}
           />
         );

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -44,14 +44,14 @@ class Auth extends React.Component {
     const { code } = this.props.location.query
 
     // Post it to the API to be verified by GitHub as authentic
-    axios.post(`${API_URL}/auth`, { code })
+    return axios.post(`${API_URL}/auth`, { code })
       .then(res => {
         // Code was accepted, so extract and save the token from the response
         const { token } = res.data;
         cookie.save('token', token, { path: '/' });
 
         // Return Promise to get the user's basic info
-        axios.get('https://api.github.com/user', {
+        return axios.get('https://api.github.com/user', {
           headers: {
             Accept: 'application/json',
             Authorization: `token ${token}`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Users will now receive distinct error messages based on the response code
400: `Failed to login with GitHub, sorry.`
403: `Sorry, you are not a member of an organization authorized to use this application.`
Additionally, refactored http response code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes maryvilledev/codesplain#42

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
