### PR TITLE
Refactor project to use dispatched save actions

### DIFF
--- a/__tests__/actions/app.js
+++ b/__tests__/actions/app.js
@@ -175,63 +175,97 @@ describe('Actions: App', () => {
       expect(actions.saveFailed()).toEqual(expected);
     });
   });
-  // describe('async actions', () => {
-  //   const middlewares = [ thunk ];
-  //   const mockStore = configureMockStore(middlewares);
-  //   const mockId = 0;
-  //
-  //   beforeEach(() => {
-  //     moxios.install();
-  //   });
-  //   afterEach(() => {
-  //     cookie.remove('username');
-  //     moxios.uninstall();
-  //   });
-  //   describe('save()', () => {
-  //     it('dispatches no additional actions if not logged in', () => {
-  //       const store = mockStore({});
-  //       return store.dispatch(actions.saveState(mockId))
-  //         .then(() => { // return of async actions
-  //         expect(store.getActions()).toEqual([])
-  //       });
-  //     });
-  //     it('creates SAVE_SUCCEEDED if saved', () => {
-  //       moxios.wait(() => {
-  //         const request = moxios.requests.mostRecent();
-  //         request.respondWith({
-  //           status: 200,
-  //           response: { id: mockId, status: '200' },
-  //         });
-  //       });
-  //       cookie.save('username', 'foo');
-  //       const expectedActions = [
-  //         { type: actions.SAVE_STARTED, },
-  //         { type: actions.SAVE_SUCCEEDED, },
-  //       ];
-  //       const store = mockStore({});
-  //       return store.dispatch(actions.saveState(mockId))
-  //         .then(() => { // return of async actions
-  //         expect(store.getActions()).toEqual(expectedActions)
-  //       });
-  //     });
-  //     it('creates SAVE_FAILED if save failed', () => {
-  //       moxios.wait(() => {
-  //         const request = moxios.requests.mostRecent();
-  //         request.respondWith({
-  //           status: 400,
-  //         });
-  //       });
-  //       cookie.save('username', 'foo');
-  //       const expectedActions = [
-  //         { type: actions.SAVE_STARTED, },
-  //         { type: actions.SAVE_FAILED, },
-  //       ];
-  //       const store = mockStore({});
-  //       return store.dispatch(actions.saveState(mockId))
-  //         .then(() => { // return of async actions
-  //         expect(store.getActions()).toEqual(expectedActions)
-  //       });
-  //     });
-  //   });
-  // });
+  describe('async actions', () => {
+    const middlewares = [ thunk ];
+    const mockStore = configureMockStore(middlewares);
+
+    beforeEach(() => {
+      cookie.save('token', 'rick')
+      cookie.save('username', 'morty');
+      moxios.install();
+    });
+    afterEach(() => {
+      cookie.remove('token');
+      cookie.remove('username');
+      moxios.uninstall();
+    });
+    describe('saveNew()', () => {
+      it('dispatches SAVE_SUCCEEDED if saved', () => {
+        const key = 'gazorpazorp';
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent();
+          request.respondWith({
+            status: 200,
+            response: { key, status: '200' },
+          });
+        });
+        const expectedActions = [
+          { type: actions.SAVE_STARTED, },
+          { type: actions.SAVE_SUCCEEDED, },
+        ];
+        const store = mockStore({});
+        return store.dispatch(actions.saveNew())
+          .then((returnVal) => { // return of async actions
+            expect(store.getActions()).toEqual(expectedActions);
+            expect(returnVal).toEqual(key);
+          });
+      });
+      it('dispatches SAVE_FAILED if save failed', () => {
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent();
+          request.respondWith({
+            status: 400,
+          });
+        });
+        const expectedActions = [
+          { type: actions.SAVE_STARTED, },
+          { type: actions.SAVE_FAILED, },
+        ];
+        const store = mockStore({});
+        return store.dispatch(actions.saveNew())
+          .then(() => { // return of async actions
+            expect(store.getActions()).toEqual(expectedActions)
+          });
+      });
+    });
+    describe('saveExisting()', () => {
+      it('description', () => {
+        it('dispatches SAVE_SUCCEEDED if saved', () => {
+          moxios.wait(() => {
+            const request = moxios.requests.mostRecent();
+            request.respondWith({
+              status: 200,
+              response: { key, status: '200' },
+            });
+          });
+          const expectedActions = [
+            { type: actions.SAVE_STARTED, },
+            { type: actions.SAVE_SUCCEEDED, },
+          ];
+          const store = mockStore({ snippetTitle: 'foo' });
+          return store.dispatch(actions.saveExisting())
+            .then(() => { // return of async actions
+              expect(store.getActions()).toEqual(expectedActions);
+            });
+        });
+        it('dispatches SAVE_FAILED if save failed', () => {
+          moxios.wait(() => {
+            const request = moxios.requests.mostRecent();
+            request.respondWith({
+              status: 400,
+            });
+          });
+          const expectedActions = [
+            { type: actions.SAVE_STARTED, },
+            { type: actions.SAVE_FAILED, },
+          ];
+          const store = mockStore({});
+          return store.dispatch(actions.saveExisting())
+            .then(() => { // return of async actions
+              expect(store.getActions()).toEqual(expectedActions)
+            });
+        });
+      });
+    });
+  });
 });

--- a/__tests__/actions/app.js
+++ b/__tests__/actions/app.js
@@ -151,102 +151,87 @@ describe('Actions: App', () => {
       expect(actions.parseSnippet(snippet)).toEqual(expected);
     });
   });
-  describe('CLEAR_UNSAVED_CHANGES', () => {
-    it('creates an action to clear the flag that denotes unsaved changes', () => {
+  describe('SAVE_STARTED', () => {
+    it('creates the correct action object', () => {
       const expected = {
-        type: actions.CLEAR_UNSAVED_CHANGES,
+        type: actions.SAVE_STARTED,
       };
-      expect(actions.clearUnsavedChanges()).toEqual(expected)
+      expect(actions.saveStarted()).toEqual(expected);
     });
   });
-  describe('SAVE_STATE_STARTED', () => {
-    it('creates an action to notify state save has started', () => {
+  describe('SAVE_SUCCEEDED', () => {
+    it('creates the correct action object', () => {
       const expected = {
-        type: actions.SAVE_STATE_STARTED,
+        type: actions.SAVE_SUCCEEDED,
       };
-      expect(actions.saveStateStarted()).toEqual(expected);
+      expect(actions.saveSucceeded()).toEqual(expected);
     });
   });
-  describe('SAVE_STATE_SUCCEEDED', () => {
-    it('creates an action to notify state save has succeeded', () => {
+  describe('SAVE_FAILED', () => {
+    it('creates the correct action object', () => {
       const expected = {
-        type: actions.SAVE_STATE_SUCCEEDED,
+        type: actions.SAVE_FAILED,
       };
-      expect(actions.saveStateSucceeded()).toEqual(expected);
+      expect(actions.saveFailed()).toEqual(expected);
     });
   });
-  describe('SAVE_STATE_FAILED', () => {
-    it('creates an action to notify state save has failed', () => {
-      const expected = {
-        type: actions.SAVE_STATE_FAILED,
-      };
-      expect(actions.saveStateFailed()).toEqual(expected);
-    });
-  });
-  describe('async actions', () => {
-    const middlewares = [ thunk ];
-    const mockStore = configureMockStore(middlewares);
-    const mockId = 0;
-
-    beforeEach(() => {
-      moxios.install();
-    });
-    afterEach(() => {
-      cookie.remove('username');
-      moxios.uninstall();
-    });
-    describe('SAVE_STATE', () => {
-      it('dispatches no additional actions if an id is not supplied', () => {
-        const store = mockStore({});
-        return store.dispatch(actions.saveState())
-          .then(() => { // return of async actions
-          expect(store.getActions()).toEqual([])
-        });
-      });
-      it('dispatches no additional actions if not logged in', () => {
-        const store = mockStore({});
-        return store.dispatch(actions.saveState(mockId))
-          .then(() => { // return of async actions
-          expect(store.getActions()).toEqual([])
-        });
-      });
-      it('creates SAVE_STATE_SUCCEEDED if saved', () => {
-        moxios.wait(() => {
-          const request = moxios.requests.mostRecent();
-          request.respondWith({
-            status: 200,
-            response: { id: mockId, status: '200' },
-          });
-        });
-        cookie.save('username', 'foo');
-        const expectedActions = [
-          { type: actions.SAVE_STATE_STARTED, },
-          { type: actions.SAVE_STATE_SUCCEEDED, },
-        ];
-        const store = mockStore({});
-        return store.dispatch(actions.saveState(mockId))
-          .then(() => { // return of async actions
-          expect(store.getActions()).toEqual(expectedActions)
-        });
-      });
-      it('creates SAVE_STATE_FAILED if save failed', () => {
-        moxios.wait(() => {
-          const request = moxios.requests.mostRecent();
-          request.respondWith({
-            status: 400,
-          });
-        });
-        cookie.save('username', 'foo');
-        const expectedActions = [
-          { type: actions.SAVE_STATE_STARTED, },
-          { type: actions.SAVE_STATE_FAILED, },
-        ];
-        const store = mockStore({});
-        return store.dispatch(actions.saveState(mockId))
-          .then(() => { // return of async actions
-          expect(store.getActions()).toEqual(expectedActions)
-        });
-      });
-    });
-  });
+  // describe('async actions', () => {
+  //   const middlewares = [ thunk ];
+  //   const mockStore = configureMockStore(middlewares);
+  //   const mockId = 0;
+  //
+  //   beforeEach(() => {
+  //     moxios.install();
+  //   });
+  //   afterEach(() => {
+  //     cookie.remove('username');
+  //     moxios.uninstall();
+  //   });
+  //   describe('save()', () => {
+  //     it('dispatches no additional actions if not logged in', () => {
+  //       const store = mockStore({});
+  //       return store.dispatch(actions.saveState(mockId))
+  //         .then(() => { // return of async actions
+  //         expect(store.getActions()).toEqual([])
+  //       });
+  //     });
+  //     it('creates SAVE_SUCCEEDED if saved', () => {
+  //       moxios.wait(() => {
+  //         const request = moxios.requests.mostRecent();
+  //         request.respondWith({
+  //           status: 200,
+  //           response: { id: mockId, status: '200' },
+  //         });
+  //       });
+  //       cookie.save('username', 'foo');
+  //       const expectedActions = [
+  //         { type: actions.SAVE_STARTED, },
+  //         { type: actions.SAVE_SUCCEEDED, },
+  //       ];
+  //       const store = mockStore({});
+  //       return store.dispatch(actions.saveState(mockId))
+  //         .then(() => { // return of async actions
+  //         expect(store.getActions()).toEqual(expectedActions)
+  //       });
+  //     });
+  //     it('creates SAVE_FAILED if save failed', () => {
+  //       moxios.wait(() => {
+  //         const request = moxios.requests.mostRecent();
+  //         request.respondWith({
+  //           status: 400,
+  //         });
+  //       });
+  //       cookie.save('username', 'foo');
+  //       const expectedActions = [
+  //         { type: actions.SAVE_STARTED, },
+  //         { type: actions.SAVE_FAILED, },
+  //       ];
+  //       const store = mockStore({});
+  //       return store.dispatch(actions.saveState(mockId))
+  //         .then(() => { // return of async actions
+  //         expect(store.getActions()).toEqual(expectedActions)
+  //       });
+  //     });
+  //   });
+  // });
 });

--- a/__tests__/reducers/app.js
+++ b/__tests__/reducers/app.js
@@ -191,7 +191,11 @@ describe('Reducer: App', () => {
       type: actions.RESTORE_STATE,
       payload: savedState
     };
-    expect(reducer(undefined, action)).toEqual(savedState);
+    const expected = {
+      ...savedState,
+      hasUnsavedChanges: false,
+    };
+    expect(reducer(undefined, action)).toEqual(expected);
   });
   it('should handle SET_SNIPPET_TITLE', () => {
     const snippetTitle = 'Get Schwifty'
@@ -274,12 +278,12 @@ describe('Reducer: App', () => {
       expect(reducer(undefined, action)).toEqual(expected);
     });
   });
-  it('should handle SAVE_STATE_SUCCEEDED', () => {
+  it('should handle SAVE_SUCCEEDED', () => {
     const state = {
       hasUnsavedChanges: true,
     };
     const action = {
-      type: actions.SAVE_STATE_SUCCEEDED,
+      type: actions.SAVE_SUCCEEDED,
     };
     const expected = {
       hasUnsavedChanges: false,

--- a/__tests__/util/requests.test.js
+++ b/__tests__/util/requests.test.js
@@ -1,0 +1,19 @@
+import * as reqUtils from '../../src/util/requests';
+
+const API_URL = process.env.REACT_APP_API_URL;
+
+describe('util: requests', () => {
+  describe('makeSaveEndpointUrl', () => {
+    it('makes a new POST endpoint given a username', () => {
+      const username = 'RickSanchez';
+      const expected = `${API_URL}/users/${username}/snippets`;
+      expect(reqUtils.makeSaveEndpointUrl(username)).toEqual(expected);
+    });
+    it('makes a new PUT endpoint given a username and snippetId', () => {
+      const username = 'RickSanchez';
+      const snippet = 'portalGun';
+      const expected = `${API_URL}/users/${username}/snippets/${snippet}`;
+      expect(reqUtils.makeSaveEndpointUrl(username, snippet)).toEqual(expected);
+    });
+  });
+});

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -1,25 +1,23 @@
 import axios from 'axios';
 import cookie from 'react-cookie';
 
-export const CLEAR_UNSAVED_CHANGES = 'CLEAR_UNSAVED_CHANGES';
+import { makeSaveEndpointUrl } from '../util/requests';
+
 export const EDIT_ANNOTATION = 'EDIT_ANNOTATION';
 export const PARSE_SNIPPET = 'PARSE_SNIPPET';
-export const RESTORE_STATE = 'RESTORE_STATE';
 export const RESET_RULE_FILTERS = 'RESET_RULE_FILTERS';
+export const RESTORE_STATE = 'RESTORE_STATE';
 export const SAVE_ANNOTATION = 'SAVE_ANNOTATION';
+export const SAVE_FAILED = 'SAVE_FAILED';
+export const SAVE_STARTED = 'SAVE_STARTED';
+export const SAVE_SUCCEEDED = 'SAVE_SUCCEEDED';
+export const SELECT_ALL_FILTERS = 'SELECT_ALL_FILTERS';
 export const SET_AST = 'SET_AST';
 export const SET_RULE_FILTERS = 'SET_RULE_FILTERS';
 export const SET_SNIPPET_CONTENTS = 'SET_SNIPPET_CONTENTS';
 export const SET_SNIPPET_LANGUAGE = 'SET_SNIPPET_LANGUAGE';
 export const SET_SNIPPET_TITLE = 'SET_SNIPPET_TITLE';
 export const TOGGLE_EDITING_STATE = 'TOGGLE_EDITING_STATE';
-export const SAVE_STATE = 'SAVE_STATE';
-export const SAVE_STATE_STARTED = 'SAVE_STATE_STARTED';
-export const SAVE_STATE_SUCCEEDED = 'SAVE_STATE_SUCCEEDED';
-export const SAVE_STATE_FAILED = 'SAVE_STATE_FAILED';
-export const SELECT_ALL_FILTERS = 'SELECT_ALL_FILTERS';
-
-const API_URL = process.env.REACT_APP_API_URL;
 
 export const setSnippetContents = (snippet) => ({
   type: SET_SNIPPET_CONTENTS,
@@ -78,39 +76,69 @@ export const parseSnippet = (snippet) => ({
   },
 });
 
-export const clearUnsavedChanges = () => ({
-  type: CLEAR_UNSAVED_CHANGES,
-})
-
-export const saveStateStarted = () => ({
-  type: SAVE_STATE_STARTED,
+export const saveStarted = () => ({
+  type: SAVE_STARTED,
 });
 
-export const saveStateSucceeded = () => ({
-  type: SAVE_STATE_SUCCEEDED,
+export const saveSucceeded = () => ({
+  type: SAVE_SUCCEEDED,
 });
 
-export const saveStateFailed = () => ({
-  type: SAVE_STATE_FAILED,
+export const saveFailed = () => ({
+  type: SAVE_FAILED,
 });
 
-export const saveState = (id) => {
+export const saveNew = () => {
   return (dispatch, getState) => {
-    // If the snippet has not been saved, then saving an annotation shouldn't
-    // trigger a POST request to save the snippet (and its annotations)
+    // Load the token and username from cookie storage
+    const token = cookie.load('token');
     const username = cookie.load('username');
-    if (id === undefined || !username) {
-      // Return a Promise object to make this action "thenable"
-      return Promise.resolve();
-    }
-    dispatch(saveStateStarted());
-    // Get the app state and stringify it
-    const stateString = JSON.stringify(getState().app);
-    return axios.post(`${API_URL}/users/${username}/snippets/${id}`, { json: stateString, })
+
+    // Construct the necessary request objects
+    const reqBody = JSON.stringify(getState().app);
+    const reqHeaders = {
+      headers: {
+        Authorization: token,
+      },
+    };
+
+    // Save the new snippet
+    return axios.post(makeSaveEndpointUrl(username), reqBody, reqHeaders)
       .then((res) => {
-        dispatch(saveStateSucceeded());
-      }, (err) => {
-        dispatch(saveStateFailed());
+        dispatch(saveSucceeded());
+        // Return the key of the newly-saved snippet so that the browser
+        // location can be updated
+        return res.data.key;
+      }, () => {
+        dispatch(saveFailed());
+      });
+  };
+};
+
+export const saveExisting = () => {
+  return (dispatch, getState) => {
+    // Load the token and username from cookie storage
+    const token = cookie.load('token');
+    const username = cookie.load('username');
+
+    // Get the app state to save (and the snippet title to save to)
+    const appState = getState().app;
+    const { snippetTitle: title } = appState;
+
+    // Construct the necessary request objects
+    const reqBody = JSON.stringify(appState);
+    const reqHeaders = {
+      headers: {
+        Authorization: token,
+      },
+    };
+
+    // Update the snippet
+    return axios.put(makeSaveEndpointUrl(username, title), reqBody, reqHeaders)
+      .then(() => {
+        dispatch(saveSucceeded());
+      }, () => {
+        dispatch(saveFailed());
       });
   };
 };

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -101,7 +101,7 @@ export const saveNew = () => {
         Authorization: token,
       },
     };
-
+    dispatch(saveStarted());
     // Save the new snippet
     return axios.post(makeSaveEndpointUrl(username), reqBody, reqHeaders)
       .then((res) => {
@@ -132,7 +132,7 @@ export const saveExisting = () => {
         Authorization: token,
       },
     };
-
+    dispatch(saveStarted());
     // Update the snippet
     return axios.put(makeSaveEndpointUrl(username, title), reqBody, reqHeaders)
       .then(() => {

--- a/src/containers/Annotations.jsx
+++ b/src/containers/Annotations.jsx
@@ -8,7 +8,7 @@ import {
 
 import {
   saveAnnotation,
-  saveState,
+  saveExisting,
 } from '../actions/app';
 
 import AnnotationPanel from '../components/AnnotationPanel';
@@ -29,13 +29,13 @@ export class Annotations extends React.Component {
   }
 
   handleSaveAnnotation(annotation) {
-    const { dispatch, id, snippetInformation } = this.props;
+    const { dispatch, snippetInformation } = this.props;
     const annotationData = {
       annotation,
       ...snippetInformation,
     };
     dispatch(saveAnnotation(annotationData));
-    dispatch(saveState(id));
+    dispatch(saveExisting());
   }
 
   render() {

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import _ from 'lodash';
 import { CardText, Snackbar } from 'material-ui';
 import React, { PropTypes } from 'react';
@@ -7,8 +6,9 @@ import { connect } from 'react-redux';
 import { browserHistory } from 'react-router';
 
 import {
-  clearUnsavedChanges,
   parseSnippet,
+  saveNew,
+  saveExisting,
   setSnippetContents,
   setSnippetLanguage,
   setSnippetTitle,
@@ -124,7 +124,6 @@ export class SnippetArea extends React.Component {
   handleSave() {
     // Make sure title is populated
     const {
-      appState,
       dispatch,
       id,
       snippetTitle,
@@ -144,33 +143,22 @@ export class SnippetArea extends React.Component {
       return;
     }
 
-    // Save the snippet
-    const stateString = JSON.stringify(appState);
-    const token = cookie.load('token');
-    const config = {
-      headers: {
-        'Authorization': token,
-      }
-    }
-    if (id) { // if we're updating an existing snippet...
-      axios.put(`${API_URL}/users/${username}/snippets/${id}`, stateString, config)
-        .then(res => {
+     // Update a pre-existing snippet
+    if (id) {
+      return dispatch(saveExisting())
+        .then(() => {
           this.showSnackbar('Codesplaination Saved!');
-          dispatch(clearUnsavedChanges());
-        }, err => {
-          this.showSnackbar('Failed to save - an error occurred');
-        })
-    }
-    else { // if we're saving a new snippet...
-      axios.post(`${API_URL}/users/${username}/snippets`, stateString, config)
-        .then((res) => {
-          browserHistory.push(`/${username}/${res.data.key}`);
-          this.showSnackbar('Codesplaination Saved!');
-          dispatch(clearUnsavedChanges());
-        }, (err) => {
+        }, () => {
           this.showSnackbar('Failed to save - an error occurred');
         });
     }
+    return dispatch(saveNew())
+      .then((snippetTitle) => {
+        browserHistory.push(`/${username}/${snippetTitle}`);
+        this.showSnackbar('Codesplaination Saved!');
+      }, () => {
+        this.showSnackbar('Failed to save - an error occurred');
+      });
   }
 
   handleSaveAs(title) {
@@ -188,31 +176,21 @@ export class SnippetArea extends React.Component {
 
     // Render the new title
     const {
-      appState,
       dispatch,
     } = this.props;
     dispatch(setSnippetTitle(title));
 
     // Save the snippet
-    appState.snippetTitle = title;
-    const stateString = JSON.stringify(appState);
-    const token = cookie.load('token');
-    const config = {
-      headers: {
-        'Authorization': token,
-      }
-    }
-    axios.post(`${API_URL}/users/${username}/snippets`, stateString, config)
-      .then((res) => {
-        browserHistory.push(`/${username}/${res.data.key}`);
+    return dispatch(saveNew())
+      .then((snippetTitle) => {
+        browserHistory.push(`/${username}/${snippetTitle}`);
         this.showSnackbar('Codesplaination Saved!');
-        dispatch(clearUnsavedChanges());
         const permissions = {
           canRead: true,
           canEdit: true
         } //All permission, this is now her file.
         dispatch(setPermissions(permissions))
-      }, (err) => {
+      }, () => {
         this.showSnackbar('Failed to save - an error occurred');
       });
   }

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -81,7 +81,10 @@ const app = (state = initialState, action) => {
       };
     }
     case actions.RESTORE_STATE: {
-      return action.payload
+      return {
+        ...action.payload,
+        hasUnsavedChanges: false,
+      };
     }
     case actions.SET_SNIPPET_TITLE: {
       return {
@@ -90,7 +93,7 @@ const app = (state = initialState, action) => {
         snippetTitle: action.payload
       };
     }
-    case actions.SAVE_STATE_SUCCEEDED: {
+    case actions.SAVE_SUCCEEDED: {
       return {
         ...state,
         hasUnsavedChanges: false,

--- a/src/util/requests.js
+++ b/src/util/requests.js
@@ -1,0 +1,13 @@
+const API_URL = process.env.REACT_APP_API_URL;
+
+/* Construct the endpoint to make a REST request to. Only the username is
+ * field is required; the snippetId will be left blank for POST requests,
+ * and can be supplied when needed (say, for PUT requests).
+ *
+ */
+export const makeSaveEndpointUrl = (username, snippetId = '') => {
+  if (snippetId) {
+    return `${API_URL}/users/${username}/snippets/${snippetId}`;
+  }
+  return `${API_URL}/users/${username}/snippets`;
+}

--- a/src/util/requests.js
+++ b/src/util/requests.js
@@ -3,11 +3,12 @@ const API_URL = process.env.REACT_APP_API_URL;
 /* Construct the endpoint to make a REST request to. Only the username is
  * field is required; the snippetId will be left blank for POST requests,
  * and can be supplied when needed (say, for PUT requests).
- *
  */
 export const makeSaveEndpointUrl = (username, snippetId = '') => {
   if (snippetId) {
+    // Return a URL for PUT requests
     return `${API_URL}/users/${username}/snippets/${snippetId}`;
   }
+  // Return a URL for POST requests
   return `${API_URL}/users/${username}/snippets`;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR refactors the project to use dispatched Redux actions to save the state. Container components do not make the save requests themselves but instead dispatch an action to do so.

## Motivation and Context
Fixes #271 
Previously, container components that needed to make a request to save the state would simply do it themselves, which meant that if the logic behind saving changed, then there would be multiple places in the project that would need to be refactored. Instead, there are now two redux actions, `saveNew()` and `saveExisting()`, that can be dispatched to save the state to AWS. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
