### PR TITLE
Issue355

### DIFF
--- a/__tests__/util/__snapshots__/rules.test.js.snap
+++ b/__tests__/util/__snapshots__/rules.test.js.snap
@@ -1,0 +1,129 @@
+exports[`util: rules ignored rules should match snapshot 1`] = `
+Array [
+  "atom",
+  "suite",
+  "file_input",
+  "simple_stmt",
+  "trailed_atom",
+  "trailer",
+  "comparison",
+  "testlist_comp",
+  "arglist",
+  "expr_stmt",
+  ".IF",
+  ".COLON",
+  ".NEWLINE",
+  ".INDENT",
+  ".NAME",
+  ".OPEN_PAREN",
+  ".STRING_LITERAL",
+  ".CLOSE_PAREN",
+  ".DEDENT",
+  "._EOF",
+  ".FOR",
+  ".IN",
+  ".DECIMAL_INTEGER",
+  ".COMMA",
+]
+`;
+
+exports[`util: rules rules should match snapshot 1`] = `
+Object {
+  ".FALSE": Object {
+    "color": "#E67300",
+    "prettyName": "Boolean (False)",
+  },
+  ".TRUE": Object {
+    "color": "#FF9933",
+    "prettyName": "Boolean (True)",
+  },
+  "and_expr": Object {
+    "color": "#F0E68C",
+    "prettyName": "And",
+  },
+  "argument": Object {
+    "color": "#EAF7AB",
+    "prettyName": "Arguments",
+  },
+  "arith_expr": Object {
+    "color": "#FFA500",
+    "prettyName": "Arithmetic Expression",
+  },
+  "augassign": Object {
+    "color": "#00ffff",
+    "prettyName": "Augmented Assignment",
+  },
+  "break_stmt": Object {
+    "color": "#00ffa0",
+    "prettyName": "Break Statement",
+  },
+  "classdef": Object {
+    "color": "#03C03C",
+    "prettyName": "Class Definitions",
+  },
+  "comp_op": Object {
+    "color": "#DAA520",
+    "prettyName": "Comparison Operator",
+  },
+  "dictorsetmaker": Object {
+    "color": "#00FF7F",
+    "prettyName": "Dictionary",
+  },
+  "except_clause": Object {
+    "color": "#779ECB",
+    "prettyName": "Except Clauses",
+  },
+  "expr": Object {
+    "color": "#F0ABF7",
+    "prettyName": "Expressions",
+  },
+  "for_stmt": Object {
+    "color": "#F7ABAB",
+    "prettyName": "For Loops",
+  },
+  "funcdef": Object {
+    "color": "#AEC6CF",
+    "prettyName": "Function Definitions",
+  },
+  "if_stmt": Object {
+    "color": "#FFFF00",
+    "prettyName": "If Statements",
+  },
+  "import_name": Object {
+    "color": "#FF6666",
+    "prettyName": "Import Statement",
+  },
+  "integer": Object {
+    "color": "#ABF7C6",
+    "prettyName": "Integers",
+  },
+  "number": Object {
+    "color": "#DEA5A4",
+    "prettyName": "Numbers",
+  },
+  "parameters": Object {
+    "color": "#FFB347",
+    "prettyName": "Parameters",
+  },
+  "pass_stmt": Object {
+    "color": "#FDFD96",
+    "prettyName": "Pass Statements",
+  },
+  "return_stmt": Object {
+    "color": "#EECCFF",
+    "prettyName": "Return Statement",
+  },
+  "str": Object {
+    "color": "#CAABF7",
+    "prettyName": "Strings",
+  },
+  "try_stmt": Object {
+    "color": "#CCCCFF",
+    "prettyName": "Try Statements",
+  },
+  "while_stmt": Object {
+    "color": "#F0E68C",
+    "prettyName": "While Loops",
+  },
+}
+`;

--- a/__tests__/util/rules.test.js
+++ b/__tests__/util/rules.test.js
@@ -1,6 +1,17 @@
 import * as rules from '../../src/util/rules';
 
 describe('util: rules', () => {
+  describe('rules', () => {
+    it('should match snapshot', () => {
+      expect(rules.rules).toMatchSnapshot();
+    });
+  });
+  describe('ignored rules', () => {
+    it('should match snapshot', () => {
+      expect(rules.ignoredRules).toMatchSnapshot();
+    });
+  });
+
   describe('getRuleCount()', () => {
     it('should return if node.type === undefined', () => {
       const node = {

--- a/src/util/rules.js
+++ b/src/util/rules.js
@@ -4,7 +4,6 @@ export const rules = {
   'and_expr': { prettyName: 'And', color: '#F0E68C' },
   'argument': { prettyName: 'Arguments', color: '#EAF7AB' },
   'arith_expr': { prettyName: 'Arithmetic Expression', color: '#FFA500' },
-  'atom':     { prettyName: 'Atoms', color: '#ABDBF7' },
   'augassign':   { prettyName: 'Augmented Assignment', color: '#00ffff' },
   'break_stmt': { prettyName: 'Break Statement', color: '#00ffa0' },
   'classdef': { prettyName: 'Class Definitions', color: '#03C03C' },
@@ -31,6 +30,7 @@ export const rules = {
 
 /* Array of rules produced by parser, but ignored by the UI layer */
 export const ignoredRules = [
+  'atom',
   'suite',
   'file_input',
   'simple_stmt',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR removes the `atom` rule type from the `rules` object and includes it in the `ignoredRules` objects. It also adds snapshot tests for both objects to reduce the chance of accidental changes from being merged.

## Motivation and Context
Fixes #355

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.