### PR TITLE
Reset application state when navigating to home page

### DIFF
--- a/__tests__/actions/__snapshots__/app.js.snap
+++ b/__tests__/actions/__snapshots__/app.js.snap
@@ -4,6 +4,12 @@ Object {
 }
 `;
 
+exports[`Actions: App RESET_STATE matches snapshot 1`] = `
+Object {
+  "type": "RESET_STATE",
+}
+`;
+
 exports[`Actions: App SELECT_ALL_FILTERS matches snapshot 1`] = `
 Object {
   "type": "SELECT_ALL_FILTERS",

--- a/__tests__/actions/app.js
+++ b/__tests__/actions/app.js
@@ -47,6 +47,11 @@ describe('Actions: App', () => {
       expect(actions.selectAllFilters()).toMatchSnapshot();
     });
   });
+  describe('RESET_STATE', () => {
+    it('matches snapshot', () => {
+      expect(actions.resetState()).toMatchSnapshot();
+    });
+  });
   describe('SET_AST', () => {
     it('creates an action to set the abstract syntax tree', () => {
       const AST = {

--- a/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
+++ b/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
@@ -1,33 +1,115 @@
 exports[`<CodesplainAppBar /> snapshot tests user is logged in 1`] = `
-<AppBar
-  iconElementRight={
-    <AppMenu
-      onSignOut={[Function]} />
-  }
-  onTitleTouchTap={[Function]}
-  showMenuIconButton={false}
-  style={
-    Object {
-      "cursor": "pointer",
+<div>
+  <AppBar
+    iconElementRight={
+      <AppMenu
+        onSignOut={[Function]} />
     }
-  }
-  title="Codesplain"
-  zDepth={1} />
+    onTitleTouchTap={[Function]}
+    showMenuIconButton={false}
+    style={
+      Object {
+        "cursor": "pointer",
+      }
+    }
+    title="Codesplain"
+    zDepth={1} />
+  <Dialog
+    actions={
+      Array [
+        <FlatButton
+          disabled={false}
+          fullWidth={false}
+          label="Cancel"
+          labelPosition="after"
+          labelStyle={Object {}}
+          onKeyboardFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchStart={[Function]}
+          onTouchTap={[Function]}
+          primary={false}
+          secondary={true} />,
+        <FlatButton
+          disabled={false}
+          fullWidth={false}
+          label="Discard"
+          labelPosition="after"
+          labelStyle={Object {}}
+          onKeyboardFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchStart={[Function]}
+          onTouchTap={[Function]}
+          primary={true}
+          secondary={false} />,
+      ]
+    }
+    autoDetectWindowHeight={true}
+    autoScrollBodyContent={false}
+    modal={false}
+    onRequestClose={[Function]}
+    open={false}
+    repositionOnUpdate={true}>
+    Discard unsaved changes?
+  </Dialog>
+</div>
 `;
 
 exports[`<CodesplainAppBar /> snapshot tests user is not logged in 1`] = `
-<AppBar
-  iconElementRight={
-    <LoginButton
-      onClick={[Function]} />
-  }
-  onTitleTouchTap={[Function]}
-  showMenuIconButton={false}
-  style={
-    Object {
-      "cursor": "pointer",
+<div>
+  <AppBar
+    iconElementRight={
+      <LoginButton
+        onClick={[Function]} />
     }
-  }
-  title="Codesplain"
-  zDepth={1} />
+    onTitleTouchTap={[Function]}
+    showMenuIconButton={false}
+    style={
+      Object {
+        "cursor": "pointer",
+      }
+    }
+    title="Codesplain"
+    zDepth={1} />
+  <Dialog
+    actions={
+      Array [
+        <FlatButton
+          disabled={false}
+          fullWidth={false}
+          label="Cancel"
+          labelPosition="after"
+          labelStyle={Object {}}
+          onKeyboardFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchStart={[Function]}
+          onTouchTap={[Function]}
+          primary={false}
+          secondary={true} />,
+        <FlatButton
+          disabled={false}
+          fullWidth={false}
+          label="Discard"
+          labelPosition="after"
+          labelStyle={Object {}}
+          onKeyboardFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onTouchStart={[Function]}
+          onTouchTap={[Function]}
+          primary={true}
+          secondary={false} />,
+      ]
+    }
+    autoDetectWindowHeight={true}
+    autoScrollBodyContent={false}
+    modal={false}
+    onRequestClose={[Function]}
+    open={false}
+    repositionOnUpdate={true}>
+    Discard unsaved changes?
+  </Dialog>
+</div>
 `;

--- a/__tests__/reducers/__snapshots__/app.js.snap
+++ b/__tests__/reducers/__snapshots__/app.js.snap
@@ -1,0 +1,12 @@
+exports[`Reducer: App initialState matches snapshot 1`] = `
+Object {
+  "AST": Object {},
+  "annotations": Object {},
+  "filters": Object {},
+  "hasUnsavedChanges": false,
+  "readOnly": false,
+  "snippet": "",
+  "snippetLanguage": "python3",
+  "snippetTitle": "",
+}
+`;

--- a/__tests__/reducers/app.js
+++ b/__tests__/reducers/app.js
@@ -2,18 +2,20 @@ import * as actions from '../../src/actions/app';
 import reducer, { initialState } from '../../src/reducers/app';
 
 describe('Reducer: App', () => {
-  it('should have initial state', () => {
-    const initial = {
-      annotations: {},
-      AST: {},
-      filters: {},
-      snippetLanguage: 'python3',
-      hasUnsavedChanges: false,
-      readOnly: false,
-      snippet: '',
-      snippetTitle: '',
+  describe('initialState', () => {
+    it('matches snapshot', () => {
+      expect(initialState).toMatchSnapshot();
+    });
+  });
+  it('handles RESET_STATE', () => {
+    const action = {
+      type: actions.RESET_STATE,
     };
-    expect(reducer(undefined, {})).toEqual(initial);
+    const state = {
+      foo: 'bar',
+      spam: 'eggs',
+    };
+    expect(reducer(state, action)).toEqual(initialState);
   });
   it('should handle SET_SNIPPET_CONTENTS', () => {
     const snippet = 'Show me what you got';

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -3,6 +3,7 @@ import cookie from 'react-cookie';
 
 import { makeSaveEndpointUrl } from '../util/requests';
 
+export const RESET_STATE = 'RESET_STATE';
 export const EDIT_ANNOTATION = 'EDIT_ANNOTATION';
 export const PARSE_SNIPPET = 'PARSE_SNIPPET';
 export const RESET_RULE_FILTERS = 'RESET_RULE_FILTERS';
@@ -18,6 +19,10 @@ export const SET_SNIPPET_CONTENTS = 'SET_SNIPPET_CONTENTS';
 export const SET_SNIPPET_LANGUAGE = 'SET_SNIPPET_LANGUAGE';
 export const SET_SNIPPET_TITLE = 'SET_SNIPPET_TITLE';
 export const TOGGLE_EDITING_STATE = 'TOGGLE_EDITING_STATE';
+
+export const resetState = () => ({
+  type: RESET_STATE,
+});
 
 export const setSnippetContents = (snippet) => ({
   type: SET_SNIPPET_CONTENTS,

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -8,7 +8,7 @@ export class App extends Component {
     return (
       <div className="container-fluid">
         <CodesplainAppBar />
-        <AppBody/>
+        <AppBody />
       </div>
     );
   }

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -4,6 +4,7 @@ import AppBar from 'material-ui/AppBar';
 import { withRouter } from 'react-router';
 import cookie from 'react-cookie';
 
+import { resetState } from '../actions/app';
 import LoginButton from '../components/buttons/LoginButton'
 import AppMenu from '../components/menus/AppMenu';
 
@@ -61,7 +62,8 @@ export class CodesplainAppBar extends React.Component {
   }
 
   redirectToHomePage() {
-    const { router } = this.props;
+    const { dispatch, router } = this.props;
+    dispatch(resetState());
     router.push('/');
   }
 

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -16,6 +16,11 @@ export const initialState = {
 
 const app = (state = initialState, action) => {
   switch (action.type) {
+    case actions.RESET_STATE: {
+      return {
+        ...initialState,
+      };
+    }
     case actions.SET_SNIPPET_CONTENTS: {
       return {
         ...state,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR properly resets the application state when the Codesplain logo is clicked so that the user is presented with a clean, new view. There is a check added before wiping any changes, so that if there are unsaved changes, the user will be asked to confirm navigation before doing so, and will reset state/redirect them if there are no unsaved changes.

## Motivation and Context
Fixes #366 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
