### PR TITLE
Set snippet language if snippet does not have one

### DIFF
--- a/__tests__/util/__snapshots__/state-management.test.js.snap
+++ b/__tests__/util/__snapshots__/state-management.test.js.snap
@@ -1,0 +1,5 @@
+exports[`util: state-management defaultStateValues matches snapshot 1`] = `
+Object {
+  "snippetLanguage": "python3",
+}
+`;

--- a/__tests__/util/state-management.test.js
+++ b/__tests__/util/state-management.test.js
@@ -1,0 +1,21 @@
+import * as utils from '../../src/util/state-management';
+
+describe('util: state-management', () => {
+  describe('defaultStateValues', () => {
+    it('matches snapshot', () => {
+      expect(utils.defaultStateValues).toMatchSnapshot();
+    });
+  });
+  describe('setDefaults', () => {
+    it('sets the default state values', () => {
+      expect(utils.setDefaults({})).toEqual(utils.defaultStateValues);
+    });
+    it('does not override pre-existing state properties', () => {
+      const snippetLanguage = 'java';
+      const state = {
+        snippetLanguage,
+      };
+      expect(utils.setDefaults(state).snippetLanguage).toEqual(snippetLanguage);
+    });
+  });
+});

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -13,6 +13,7 @@ import FilterArea from './FilterArea';
 import SnippetArea from './SnippetArea';
 
 import { removeDeprecatedFiltersFromState } from '../util/rules';
+import { setDefaults } from '../util/state-management';
 
 const API_URL = process.env.REACT_APP_API_URL;
 
@@ -72,7 +73,8 @@ export class AppBody extends React.Component {
           canEdit: (username === cookie.load('username')),
         };
         dispatch(setPermissions(permissions));
-        dispatch(restoreState(removeDeprecatedFiltersFromState(res.data)));
+        // dispatch(restoreState(removeDeprecatedFiltersFromState(res.data)));
+        dispatch(restoreState(setDefaults(removeDeprecatedFiltersFromState(res.data))));
         router.push(`/${username}/${id}`)
       }, () => {
         // Failed to get the snippet, either bad URL or unauthorized

--- a/src/util/state-management.js
+++ b/src/util/state-management.js
@@ -1,0 +1,14 @@
+import _ from 'lodash';
+
+export const defaultStateValues = {
+  // Default values for state should go here. If a value was already set
+  // by state, it won't be overriden by this object
+  snippetLanguage: 'python3',
+};
+
+export const setDefaults = (state) => {
+  return _.defaults(
+    {...state},
+    defaultStateValues,
+  );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a utility method to set the default state values if they aren't defined in a state object. `AppBody` uses this function to set the default snippet language (`python3`) if it is not present in a state object loaded from S3.

## Motivation and Context
Fixes #359 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
