### PR TITLE
Refactor redirectToHomePage to close annotation panel

### DIFF
--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -7,6 +7,7 @@ import { withRouter } from 'react-router';
 import cookie from 'react-cookie';
 
 import { resetState } from '../actions/app';
+import { closeAnnotationPanel } from '../actions/annotation';
 import LoginButton from '../components/buttons/LoginButton'
 import AppMenu from '../components/menus/AppMenu';
 
@@ -86,6 +87,8 @@ export class CodesplainAppBar extends React.Component {
 
     // Reset state
     dispatch(resetState());
+    // Close the annotation panel
+    dispatch(closeAnnotationPanel());
     // If the user is not already at the home page, redirect them to it
     if (router.location.pathname !== '/') {
       router.push('/');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`redirectToHomePage()` in the `CodesplainAppBar` container now dispatches an action to close the annotation panel

## Motivation and Context
Fixes #379 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
