### PR TITLE
Add buttons to view previous/next annotations

### DIFF
--- a/__tests__/components/AnnotationDisplay.test.jsx
+++ b/__tests__/components/AnnotationDisplay.test.jsx
@@ -5,23 +5,61 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 import AnnotationDisplay from '../../src/components/AnnotationDisplay';
 
-const mockFunctionProps = {
+const defaultProps = {
+  annotation: '',
   closeAnnotation: jest.fn(),
   editAnnotation: jest.fn(),
+  getNextAnnotation: jest.fn(),
+  getPreviousAnnotation: jest.fn(),
+  hasNextAnnotation: false,
+  hasPrevAnnotation: false,
 };
 
 describe('<AnnotationDisplay />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, { context: { muiTheme } });
 
-  it('matches snapshot', () => {
-    const wrapper = shallowWithContext(
-      <AnnotationDisplay
-        annotation={'some annotation'}
-        {...mockFunctionProps}
-      />
-    );
-    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  describe('snapshots', () => {
+    describe('when no annotations before/after current one exist', () => {
+      it('matches snapshot', () => {
+        const wrapper = shallowWithContext(<AnnotationDisplay {...defaultProps}/>);
+        expect(shallowToJson(wrapper)).toMatchSnapshot();
+      });
+    });
+    describe('when an annotation after current one exists', () => {
+      it('matches snapshot', () => {
+        const wrapper = shallowWithContext(
+          <AnnotationDisplay
+            {...defaultProps}
+            hasNextAnnotation
+          />
+        );
+        expect(shallowToJson(wrapper)).toMatchSnapshot();
+      });
+    });
+    describe('when an annotation before current one exists', () => {
+      it('matches snapshot', () => {
+         const wrapper = shallowWithContext(
+           <AnnotationDisplay
+             {...defaultProps}
+             hasPrevAnnotation
+           />
+         );
+         expect(shallowToJson(wrapper)).toMatchSnapshot();
+       });
+    });
+    describe('when annotation exists before/after current one', () => {
+      it('matches snapshot', () => {
+         const wrapper = shallowWithContext(
+           <AnnotationDisplay
+             {...defaultProps}
+             hasNextAnnotation
+             hasPrevAnnotation
+           />
+         );
+         expect(shallowToJson(wrapper)).toMatchSnapshot();
+      });
+    });
   });
 
   describe('prop: annotation', () => {
@@ -29,8 +67,8 @@ describe('<AnnotationDisplay />', () => {
       const annotation = 'Wubba lubba dub dub!';
       const wrapper = shallowWithContext(
         <AnnotationDisplay
+          {...defaultProps}
           annotation={annotation}
-          {...mockFunctionProps}
         />
       );
       expect(wrapper.find('MarkdownRenderer').prop('markdown')).toEqual(annotation);

--- a/__tests__/components/AnnotationPanel.test.jsx
+++ b/__tests__/components/AnnotationPanel.test.jsx
@@ -7,8 +7,20 @@ import AnnotationPanel from '../../src/components/AnnotationPanel';
 
 const mockFunctionProps = {
   closeAnnotation: jest.fn(),
+  getNextAnnotation: jest.fn(),
+  getPreviousAnnotation: jest.fn(),
   saveAnnotation: jest.fn(),
 };
+const defaultProps = {
+  ...mockFunctionProps,
+  annotation: '',
+  lineAnnotated: {
+    lineNumber: 0,
+    lineText: 'You don\'t know me!',
+  },
+  hasNextAnnotation: false,
+  hasPrevAnnotation: false,
+}
 
 describe('<AnnotationPanel />', () => {
   const muiTheme = getMuiTheme();
@@ -18,12 +30,7 @@ describe('<AnnotationPanel />', () => {
     it('matches snapshot when no annotation is saved for a line', () => {
       const wrapper = shallowWithContext(
         <AnnotationPanel
-          annotation=''
-          lineAnnotated={{
-            lineNumber: 0,
-            lineText: 'True',
-          }}
-          {...mockFunctionProps}
+          {...defaultProps}
         />
       );
       expect(shallowToJson(wrapper)).toMatchSnapshot();
@@ -32,12 +39,8 @@ describe('<AnnotationPanel />', () => {
     it('matches snapshot when an annotation is saved for a line', () => {
       const wrapper = shallowWithContext(
         <AnnotationPanel
+          {...defaultProps}
           annotation='Wubba lubba dub dub!'
-          lineAnnotated={{
-            lineNumber: 0,
-            lineText: 'True',
-          }}
-          {...mockFunctionProps}
         />
       );
       expect(shallowToJson(wrapper)).toMatchSnapshot();
@@ -46,20 +49,20 @@ describe('<AnnotationPanel />', () => {
 
   describe('prop: lineAnnotated', () => {
     it('is forwarded to LineSnippet', () => {
-      const lineInfo = {
+      const lineAnnotated = {
         lineNumber: 0,
         lineText: 'You pass butter',
       };
       const wrapper = shallowWithContext(
         <AnnotationPanel
+          {...defaultProps}
           annotation='some annotation'
-          lineAnnotated={lineInfo}
-          {...mockFunctionProps}
+          lineAnnotated={lineAnnotated}
         />
       );
       const lineSnippet = wrapper.find('LineSnippet');
-      expect(lineSnippet.prop('lineNumber')).toEqual(Number(lineInfo['lineNumber']) + 1);
-      expect(lineSnippet.prop('value')).toEqual(lineInfo['lineText']);
+      expect(lineSnippet.prop('lineNumber')).toEqual(Number(lineAnnotated['lineNumber']) + 1);
+      expect(lineSnippet.prop('value')).toEqual(lineAnnotated['lineText']);
     });
   });
 });

--- a/__tests__/components/AnnotationPanel.test.jsx
+++ b/__tests__/components/AnnotationPanel.test.jsx
@@ -19,7 +19,7 @@ describe('<AnnotationPanel />', () => {
       const wrapper = shallowWithContext(
         <AnnotationPanel
           annotation=''
-          snippetInformation={{
+          lineAnnotated={{
             lineNumber: 0,
             lineText: 'True',
           }}
@@ -33,7 +33,7 @@ describe('<AnnotationPanel />', () => {
       const wrapper = shallowWithContext(
         <AnnotationPanel
           annotation='Wubba lubba dub dub!'
-          snippetInformation={{
+          lineAnnotated={{
             lineNumber: 0,
             lineText: 'True',
           }}
@@ -44,7 +44,7 @@ describe('<AnnotationPanel />', () => {
     });
   });
 
-  describe('prop: snippetInformation', () => {
+  describe('prop: lineAnnotated', () => {
     it('is forwarded to LineSnippet', () => {
       const lineInfo = {
         lineNumber: 0,
@@ -53,7 +53,7 @@ describe('<AnnotationPanel />', () => {
       const wrapper = shallowWithContext(
         <AnnotationPanel
           annotation='some annotation'
-          snippetInformation={lineInfo}
+          lineAnnotated={lineInfo}
           {...mockFunctionProps}
         />
       );

--- a/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
@@ -24,5 +24,23 @@ exports[`<AnnotationDisplay /> matches snapshot 1`] = `
     onTouchTap={[Function]}
     primary={true}
     secondary={false} />
+  <IconButton
+    disableTouchRipple={false}
+    disabled={false}
+    iconStyle={Object {}}
+    tooltip="View previous annotation"
+    tooltipPosition="bottom-center"
+    touch={false}>
+    <ImageNavigateBefore />
+  </IconButton>
+  <IconButton
+    disableTouchRipple={false}
+    disabled={false}
+    iconStyle={Object {}}
+    tooltip="View next annotation"
+    tooltipPosition="bottom-center"
+    touch={false}>
+    <ImageNavigateNext />
+  </IconButton>
 </div>
 `;

--- a/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
@@ -8,44 +8,65 @@ exports[`<AnnotationDisplay /> snapshots when an annotation after current one ex
         "langPrefix": "hljs language-",
       }
     } />
-  <RaisedButton
-    disabled={false}
-    fullWidth={false}
-    label="Close"
-    labelPosition="after"
-    onTouchTap={[Function]}
-    primary={false}
-    secondary={true} />
-  <RaisedButton
-    disabled={false}
-    fullWidth={false}
-    label="Edit"
-    labelPosition="after"
-    onTouchTap={[Function]}
-    primary={true}
-    secondary={false} />
-  <IconButton
-    disableTouchRipple={false}
-    disabled={false}
-    iconStyle={Object {}}
-    id="previous-annotation"
-    onTouchTap={[Function]}
-    tooltip="View previous annotation"
-    tooltipPosition="bottom-center"
-    touch={false}>
-    <ImageNavigateBefore />
-  </IconButton>
-  <IconButton
-    disableTouchRipple={false}
-    disabled={true}
-    iconStyle={Object {}}
-    id="next-annotation"
-    onTouchTap={[Function]}
-    tooltip="View next annotation"
-    tooltipPosition="bottom-center"
-    touch={false}>
-    <ImageNavigateNext />
-  </IconButton>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexFlow": "row wrap",
+        "justifyContent": "space-between",
+      }
+    }>
+    <div>
+      <RaisedButton
+        disabled={false}
+        fullWidth={false}
+        label="Close"
+        labelPosition="after"
+        onTouchTap={[Function]}
+        primary={false}
+        secondary={true} />
+      <RaisedButton
+        disabled={false}
+        fullWidth={false}
+        label="Edit"
+        labelPosition="after"
+        onTouchTap={[Function]}
+        primary={true}
+        secondary={false} />
+    </div>
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "flex": "0 1 auto",
+          "justifyContent": "flex-end",
+        }
+      }>
+      <IconButton
+        disableTouchRipple={false}
+        disabled={false}
+        iconStyle={Object {}}
+        id="previous-annotation"
+        onTouchTap={[Function]}
+        tooltip="Previous Annotation"
+        tooltipPosition="bottom-center"
+        touch={true}>
+        <NavigationArrowBack />
+      </IconButton>
+      <IconButton
+        disableTouchRipple={false}
+        disabled={true}
+        iconStyle={Object {}}
+        id="next-annotation"
+        onTouchTap={[Function]}
+        tooltip="Next Annotation"
+        tooltipPosition="bottom-center"
+        touch={true}>
+        <NavigationArrowForward />
+      </IconButton>
+    </div>
+  </div>
 </div>
 `;
 
@@ -59,44 +80,65 @@ exports[`<AnnotationDisplay /> snapshots when an annotation before current one e
         "langPrefix": "hljs language-",
       }
     } />
-  <RaisedButton
-    disabled={false}
-    fullWidth={false}
-    label="Close"
-    labelPosition="after"
-    onTouchTap={[Function]}
-    primary={false}
-    secondary={true} />
-  <RaisedButton
-    disabled={false}
-    fullWidth={false}
-    label="Edit"
-    labelPosition="after"
-    onTouchTap={[Function]}
-    primary={true}
-    secondary={false} />
-  <IconButton
-    disableTouchRipple={false}
-    disabled={true}
-    iconStyle={Object {}}
-    id="previous-annotation"
-    onTouchTap={[Function]}
-    tooltip="View previous annotation"
-    tooltipPosition="bottom-center"
-    touch={false}>
-    <ImageNavigateBefore />
-  </IconButton>
-  <IconButton
-    disableTouchRipple={false}
-    disabled={false}
-    iconStyle={Object {}}
-    id="next-annotation"
-    onTouchTap={[Function]}
-    tooltip="View next annotation"
-    tooltipPosition="bottom-center"
-    touch={false}>
-    <ImageNavigateNext />
-  </IconButton>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexFlow": "row wrap",
+        "justifyContent": "space-between",
+      }
+    }>
+    <div>
+      <RaisedButton
+        disabled={false}
+        fullWidth={false}
+        label="Close"
+        labelPosition="after"
+        onTouchTap={[Function]}
+        primary={false}
+        secondary={true} />
+      <RaisedButton
+        disabled={false}
+        fullWidth={false}
+        label="Edit"
+        labelPosition="after"
+        onTouchTap={[Function]}
+        primary={true}
+        secondary={false} />
+    </div>
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "flex": "0 1 auto",
+          "justifyContent": "flex-end",
+        }
+      }>
+      <IconButton
+        disableTouchRipple={false}
+        disabled={true}
+        iconStyle={Object {}}
+        id="previous-annotation"
+        onTouchTap={[Function]}
+        tooltip="Previous Annotation"
+        tooltipPosition="bottom-center"
+        touch={true}>
+        <NavigationArrowBack />
+      </IconButton>
+      <IconButton
+        disableTouchRipple={false}
+        disabled={false}
+        iconStyle={Object {}}
+        id="next-annotation"
+        onTouchTap={[Function]}
+        tooltip="Next Annotation"
+        tooltipPosition="bottom-center"
+        touch={true}>
+        <NavigationArrowForward />
+      </IconButton>
+    </div>
+  </div>
 </div>
 `;
 
@@ -110,44 +152,65 @@ exports[`<AnnotationDisplay /> snapshots when annotation exists before/after cur
         "langPrefix": "hljs language-",
       }
     } />
-  <RaisedButton
-    disabled={false}
-    fullWidth={false}
-    label="Close"
-    labelPosition="after"
-    onTouchTap={[Function]}
-    primary={false}
-    secondary={true} />
-  <RaisedButton
-    disabled={false}
-    fullWidth={false}
-    label="Edit"
-    labelPosition="after"
-    onTouchTap={[Function]}
-    primary={true}
-    secondary={false} />
-  <IconButton
-    disableTouchRipple={false}
-    disabled={true}
-    iconStyle={Object {}}
-    id="previous-annotation"
-    onTouchTap={[Function]}
-    tooltip="View previous annotation"
-    tooltipPosition="bottom-center"
-    touch={false}>
-    <ImageNavigateBefore />
-  </IconButton>
-  <IconButton
-    disableTouchRipple={false}
-    disabled={true}
-    iconStyle={Object {}}
-    id="next-annotation"
-    onTouchTap={[Function]}
-    tooltip="View next annotation"
-    tooltipPosition="bottom-center"
-    touch={false}>
-    <ImageNavigateNext />
-  </IconButton>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexFlow": "row wrap",
+        "justifyContent": "space-between",
+      }
+    }>
+    <div>
+      <RaisedButton
+        disabled={false}
+        fullWidth={false}
+        label="Close"
+        labelPosition="after"
+        onTouchTap={[Function]}
+        primary={false}
+        secondary={true} />
+      <RaisedButton
+        disabled={false}
+        fullWidth={false}
+        label="Edit"
+        labelPosition="after"
+        onTouchTap={[Function]}
+        primary={true}
+        secondary={false} />
+    </div>
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "flex": "0 1 auto",
+          "justifyContent": "flex-end",
+        }
+      }>
+      <IconButton
+        disableTouchRipple={false}
+        disabled={true}
+        iconStyle={Object {}}
+        id="previous-annotation"
+        onTouchTap={[Function]}
+        tooltip="Previous Annotation"
+        tooltipPosition="bottom-center"
+        touch={true}>
+        <NavigationArrowBack />
+      </IconButton>
+      <IconButton
+        disableTouchRipple={false}
+        disabled={true}
+        iconStyle={Object {}}
+        id="next-annotation"
+        onTouchTap={[Function]}
+        tooltip="Next Annotation"
+        tooltipPosition="bottom-center"
+        touch={true}>
+        <NavigationArrowForward />
+      </IconButton>
+    </div>
+  </div>
 </div>
 `;
 
@@ -161,43 +224,64 @@ exports[`<AnnotationDisplay /> snapshots when no annotations before/after curren
         "langPrefix": "hljs language-",
       }
     } />
-  <RaisedButton
-    disabled={false}
-    fullWidth={false}
-    label="Close"
-    labelPosition="after"
-    onTouchTap={[Function]}
-    primary={false}
-    secondary={true} />
-  <RaisedButton
-    disabled={false}
-    fullWidth={false}
-    label="Edit"
-    labelPosition="after"
-    onTouchTap={[Function]}
-    primary={true}
-    secondary={false} />
-  <IconButton
-    disableTouchRipple={false}
-    disabled={false}
-    iconStyle={Object {}}
-    id="previous-annotation"
-    onTouchTap={[Function]}
-    tooltip="View previous annotation"
-    tooltipPosition="bottom-center"
-    touch={false}>
-    <ImageNavigateBefore />
-  </IconButton>
-  <IconButton
-    disableTouchRipple={false}
-    disabled={false}
-    iconStyle={Object {}}
-    id="next-annotation"
-    onTouchTap={[Function]}
-    tooltip="View next annotation"
-    tooltipPosition="bottom-center"
-    touch={false}>
-    <ImageNavigateNext />
-  </IconButton>
+  <div
+    style={
+      Object {
+        "alignItems": "center",
+        "display": "flex",
+        "flexFlow": "row wrap",
+        "justifyContent": "space-between",
+      }
+    }>
+    <div>
+      <RaisedButton
+        disabled={false}
+        fullWidth={false}
+        label="Close"
+        labelPosition="after"
+        onTouchTap={[Function]}
+        primary={false}
+        secondary={true} />
+      <RaisedButton
+        disabled={false}
+        fullWidth={false}
+        label="Edit"
+        labelPosition="after"
+        onTouchTap={[Function]}
+        primary={true}
+        secondary={false} />
+    </div>
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "flex": "0 1 auto",
+          "justifyContent": "flex-end",
+        }
+      }>
+      <IconButton
+        disableTouchRipple={false}
+        disabled={false}
+        iconStyle={Object {}}
+        id="previous-annotation"
+        onTouchTap={[Function]}
+        tooltip="Previous Annotation"
+        tooltipPosition="bottom-center"
+        touch={true}>
+        <NavigationArrowBack />
+      </IconButton>
+      <IconButton
+        disableTouchRipple={false}
+        disabled={false}
+        iconStyle={Object {}}
+        id="next-annotation"
+        onTouchTap={[Function]}
+        tooltip="Next Annotation"
+        tooltipPosition="bottom-center"
+        touch={true}>
+        <NavigationArrowForward />
+      </IconButton>
+    </div>
+  </div>
 </div>
 `;

--- a/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
@@ -1,7 +1,7 @@
-exports[`<AnnotationDisplay /> matches snapshot 1`] = `
+exports[`<AnnotationDisplay /> snapshots when an annotation after current one exists matches snapshot 1`] = `
 <div>
   <MarkdownRenderer
-    markdown="some annotation"
+    markdown=""
     options={
       Object {
         "highlight": [Function],
@@ -28,6 +28,59 @@ exports[`<AnnotationDisplay /> matches snapshot 1`] = `
     disableTouchRipple={false}
     disabled={false}
     iconStyle={Object {}}
+    id="previous-annotation"
+    onTouchTap={[Function]}
+    tooltip="View previous annotation"
+    tooltipPosition="bottom-center"
+    touch={false}>
+    <ImageNavigateBefore />
+  </IconButton>
+  <IconButton
+    disableTouchRipple={false}
+    disabled={true}
+    iconStyle={Object {}}
+    id="next-annotation"
+    onTouchTap={[Function]}
+    tooltip="View next annotation"
+    tooltipPosition="bottom-center"
+    touch={false}>
+    <ImageNavigateNext />
+  </IconButton>
+</div>
+`;
+
+exports[`<AnnotationDisplay /> snapshots when an annotation before current one exists matches snapshot 1`] = `
+<div>
+  <MarkdownRenderer
+    markdown=""
+    options={
+      Object {
+        "highlight": [Function],
+        "langPrefix": "hljs language-",
+      }
+    } />
+  <RaisedButton
+    disabled={false}
+    fullWidth={false}
+    label="Close"
+    labelPosition="after"
+    onTouchTap={[Function]}
+    primary={false}
+    secondary={true} />
+  <RaisedButton
+    disabled={false}
+    fullWidth={false}
+    label="Edit"
+    labelPosition="after"
+    onTouchTap={[Function]}
+    primary={true}
+    secondary={false} />
+  <IconButton
+    disableTouchRipple={false}
+    disabled={true}
+    iconStyle={Object {}}
+    id="previous-annotation"
+    onTouchTap={[Function]}
     tooltip="View previous annotation"
     tooltipPosition="bottom-center"
     touch={false}>
@@ -37,6 +90,110 @@ exports[`<AnnotationDisplay /> matches snapshot 1`] = `
     disableTouchRipple={false}
     disabled={false}
     iconStyle={Object {}}
+    id="next-annotation"
+    onTouchTap={[Function]}
+    tooltip="View next annotation"
+    tooltipPosition="bottom-center"
+    touch={false}>
+    <ImageNavigateNext />
+  </IconButton>
+</div>
+`;
+
+exports[`<AnnotationDisplay /> snapshots when annotation exists before/after current one matches snapshot 1`] = `
+<div>
+  <MarkdownRenderer
+    markdown=""
+    options={
+      Object {
+        "highlight": [Function],
+        "langPrefix": "hljs language-",
+      }
+    } />
+  <RaisedButton
+    disabled={false}
+    fullWidth={false}
+    label="Close"
+    labelPosition="after"
+    onTouchTap={[Function]}
+    primary={false}
+    secondary={true} />
+  <RaisedButton
+    disabled={false}
+    fullWidth={false}
+    label="Edit"
+    labelPosition="after"
+    onTouchTap={[Function]}
+    primary={true}
+    secondary={false} />
+  <IconButton
+    disableTouchRipple={false}
+    disabled={true}
+    iconStyle={Object {}}
+    id="previous-annotation"
+    onTouchTap={[Function]}
+    tooltip="View previous annotation"
+    tooltipPosition="bottom-center"
+    touch={false}>
+    <ImageNavigateBefore />
+  </IconButton>
+  <IconButton
+    disableTouchRipple={false}
+    disabled={true}
+    iconStyle={Object {}}
+    id="next-annotation"
+    onTouchTap={[Function]}
+    tooltip="View next annotation"
+    tooltipPosition="bottom-center"
+    touch={false}>
+    <ImageNavigateNext />
+  </IconButton>
+</div>
+`;
+
+exports[`<AnnotationDisplay /> snapshots when no annotations before/after current one exist matches snapshot 1`] = `
+<div>
+  <MarkdownRenderer
+    markdown=""
+    options={
+      Object {
+        "highlight": [Function],
+        "langPrefix": "hljs language-",
+      }
+    } />
+  <RaisedButton
+    disabled={false}
+    fullWidth={false}
+    label="Close"
+    labelPosition="after"
+    onTouchTap={[Function]}
+    primary={false}
+    secondary={true} />
+  <RaisedButton
+    disabled={false}
+    fullWidth={false}
+    label="Edit"
+    labelPosition="after"
+    onTouchTap={[Function]}
+    primary={true}
+    secondary={false} />
+  <IconButton
+    disableTouchRipple={false}
+    disabled={false}
+    iconStyle={Object {}}
+    id="previous-annotation"
+    onTouchTap={[Function]}
+    tooltip="View previous annotation"
+    tooltipPosition="bottom-center"
+    touch={false}>
+    <ImageNavigateBefore />
+  </IconButton>
+  <IconButton
+    disableTouchRipple={false}
+    disabled={false}
+    iconStyle={Object {}}
+    id="next-annotation"
+    onTouchTap={[Function]}
     tooltip="View next annotation"
     tooltipPosition="bottom-center"
     touch={false}>

--- a/__tests__/components/__snapshots__/AnnotationPanel.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationPanel.test.jsx.snap
@@ -7,11 +7,15 @@ exports[`<AnnotationPanel /> snapshot tests matches snapshot when an annotation 
   }>
   <LineSnippet
     lineNumber={1}
-    value="True" />
+    value="You don\'t know me!" />
   <AnnotationDisplay
     annotation="Wubba lubba dub dub!"
     closeAnnotation={[Function]}
-    editAnnotation={[Function]} />
+    editAnnotation={[Function]}
+    getNextAnnotation={[Function]}
+    getPreviousAnnotation={[Function]}
+    hasNextAnnotation={false}
+    hasPrevAnnotation={false} />
 </div>
 `;
 
@@ -24,7 +28,7 @@ exports[`<AnnotationPanel /> snapshot tests matches snapshot when no annotation 
   }>
   <LineSnippet
     lineNumber={1}
-    value="True" />
+    value="You don\'t know me!" />
   <AnnotationEditor
     annotation=""
     closeAnnotation={[Function]}

--- a/__tests__/containers/Annotations.test.jsx
+++ b/__tests__/containers/Annotations.test.jsx
@@ -14,11 +14,12 @@ describe('<Annotations />', () => {
   const wrapper = shallow(
     <Annotations
       annotation={mockAnnotation}
-      isDisplayingAnnotation={true}
-      readOnly={true}
-      lineAnnotated={mocklineAnnotated}
       dispatch={mockDispatch}
+      isDisplayingAnnotation={true}
+      lineAnnotated={mocklineAnnotated}
+      readOnly={true}
       router={mockRouter}
+      snippetLanguage="python3"
     />
   );
 

--- a/__tests__/containers/Annotations.test.jsx
+++ b/__tests__/containers/Annotations.test.jsx
@@ -3,7 +3,7 @@ import { shallow, mount } from 'enzyme';
 import { Annotations } from '../../src/containers/Annotations';
 
 const mockAnnotation = "They're just robots.";
-const mockSnippetInformation = {
+const mocklineAnnotated = {
   lineNumber: 2,
   lineText: 'Galactic Imperial',
 };
@@ -16,7 +16,7 @@ describe('<Annotations />', () => {
       annotation={mockAnnotation}
       isDisplayingAnnotation={true}
       readOnly={true}
-      snippetInformation={mockSnippetInformation}
+      lineAnnotated={mocklineAnnotated}
       dispatch={mockDispatch}
       router={mockRouter}
     />
@@ -24,18 +24,6 @@ describe('<Annotations />', () => {
 
   beforeEach(() => {
     mockDispatch.mockReset();
-  });
-
-  it('saves the annotation on handleSaveAnnotation', () => {
-    const annotation = "They're bureaucrats!";
-    const expected = {
-      annotation,
-      ...mockSnippetInformation
-    };
-    wrapper.instance().handleSaveAnnotation(annotation);
-
-    const { payload } = mockDispatch.mock.calls[0][0];
-    expect(payload).toEqual(expected);
   });
 
   it('closes the annotation panel on handleCloseAnnotation', () => {

--- a/__tests__/reducers/annotation.js
+++ b/__tests__/reducers/annotation.js
@@ -5,24 +5,24 @@ describe('Reducer: Annotation', () => {
   it('should have initial state', () => {
     const initial = {
       isDisplayingAnnotation: false,
-      snippetInformation: {},
+      lineAnnotated: {},
     }
     expect(reducer(undefined, {})).toEqual(initialState);
   });
 
   it('should handle OPEN_ANNOTATION_PANEL', () => {
-    const snippetInformation = {
+    const lineAnnotated = {
       lineNumber: 1,
       lineText: 'Wubba lubba dub dub!',
     };
     const action = {
       type: actions.OPEN_ANNOTATION_PANEL,
-      payload: snippetInformation
+      payload: lineAnnotated
     }
     const expected = {
       ...initialState,
       isDisplayingAnnotation: true,
-      snippetInformation: action.payload
+      lineAnnotated: action.payload
     }
     expect(reducer(undefined, action)).toEqual(expected)
   });
@@ -34,7 +34,7 @@ describe('Reducer: Annotation', () => {
     const expected = {
       ...initialState,
       isDisplayingAnnotation: false,
-      snippetInformation: {}
+      lineAnnotated: {}
     };
     expect(reducer(undefined, action)).toEqual(expected);
   });

--- a/__tests__/util/annotations.js
+++ b/__tests__/util/annotations.js
@@ -1,0 +1,44 @@
+import * as utils from '../../src/util/annotations';
+
+const annotations = {
+  '1': 'Rick Sanchez',
+  '2': 'Morty Smith',
+  '3': 'Beth Smith',
+  '4': 'Summer Smith',
+  // No Jerry
+};
+
+describe('util: annotations:', () => {
+  describe('getAnnotatedLines', () => {
+    it('should return a sorted array of the keys', () => {
+      const expected = [1, 2, 3, 4];
+      expect(utils.getAnnotatedLines(annotations)).toEqual(expected);
+    });
+  });
+  describe('getNextAnnotation', () => {
+    it('returns the annotation after the currently displayed one', () => {
+      const lineNumber = 1;
+      const expected = annotations[lineNumber + 1];
+      const nextAnnotation = utils.getNextAnnotation(annotations, lineNumber);
+      expect(nextAnnotation).toEqual(expected);
+    });
+    it('returns undefined if there are no annotations after the currently displayed one', () => {
+      const lineNumber = 4;
+      const nextAnnotation = utils.getNextAnnotation(annotations, lineNumber);
+      expect(nextAnnotation).not.toBeDefined();
+    });
+  });
+  describe('getPreviousAnnotation', () => {
+    it('returns the annotation before the currently displayed one', () => {
+      const lineNumber = 3;
+      const expected = annotations[lineNumber - 1];
+      const prevAnnotation = utils.getPreviousAnnotation(annotations, lineNumber);
+      expect(prevAnnotation).toEqual(expected);
+    });
+    it('returns undefined if there are no annotations before the currently displayed one', () => {
+      const lineNumber = 1;
+      const prevAnnotation = utils.getPreviousAnnotation(annotations, lineNumber);
+      expect(prevAnnotation).not.toBeDefined();
+    });
+  });
+});

--- a/src/actions/annotation.js
+++ b/src/actions/annotation.js
@@ -1,9 +1,9 @@
 export const OPEN_ANNOTATION_PANEL = 'OPEN_ANNOTATION_PANEL';
 export const CLOSE_ANNOTATION_PANEL = 'CLOSE_ANNOTATION_PANEL';
 
-export const openAnnotationPanel = (snippetInformation) => ({
+export const openAnnotationPanel = (annotatedLine) => ({
   type: OPEN_ANNOTATION_PANEL,
-  payload: snippetInformation,
+  payload: annotatedLine,
 });
 
 export const closeAnnotationPanel = () => ({

--- a/src/components/AnnotationDisplay.jsx
+++ b/src/components/AnnotationDisplay.jsx
@@ -26,16 +26,17 @@ const AnnotationDisplay = (props) => {
       />
       <RaisedButton
         label="Close"
-        secondary
         onTouchTap={closeAnnotation}
+        secondary
       />
       <RaisedButton
         label="Edit"
-        primary
         onTouchTap={editAnnotation}
+        primary
       />
       <IconButton
         disabled={hasPrevAnnotation}
+        id="previous-annotation"
         onTouchTap={getPreviousAnnotation}
         tooltip="View previous annotation"
       >
@@ -43,6 +44,7 @@ const AnnotationDisplay = (props) => {
       </IconButton>
       <IconButton
         disabled={hasNextAnnotation}
+        id="next-annotation"
         onTouchTap={getNextAnnotation}
         tooltip="View next annotation"
       >

--- a/src/components/AnnotationDisplay.jsx
+++ b/src/components/AnnotationDisplay.jsx
@@ -1,6 +1,9 @@
 import React, { PropTypes } from 'react';
 import MarkdownRenderer from 'react-markdown-renderer';
 import RaisedButton from 'material-ui/RaisedButton';
+import IconButton from 'material-ui/IconButton';
+import Previous from 'material-ui/svg-icons/image/navigate-before';
+import Next from 'material-ui/svg-icons/image/navigate-next';
 
 import markdownRendererOptions from '../util/markdown-renderer-options';
 
@@ -9,6 +12,10 @@ const AnnotationDisplay = (props) => {
     annotation,
     closeAnnotation,
     editAnnotation,
+    getNextAnnotation,
+    getPreviousAnnotation,
+    hasNextAnnotation,
+    hasPrevAnnotation,
   } = props;
 
   return (
@@ -27,6 +34,20 @@ const AnnotationDisplay = (props) => {
         primary
         onTouchTap={editAnnotation}
       />
+      <IconButton
+        disabled={hasPrevAnnotation}
+        onTouchTap={getPreviousAnnotation}
+        tooltip="View previous annotation"
+      >
+        <Previous />
+      </IconButton>
+      <IconButton
+        disabled={hasNextAnnotation}
+        onTouchTap={getNextAnnotation}
+        tooltip="View next annotation"
+      >
+        <Next />
+      </IconButton>
     </div>
   );
 };
@@ -35,6 +56,10 @@ AnnotationDisplay.propTypes = {
   annotation: PropTypes.string.isRequired,
   closeAnnotation: PropTypes.func.isRequired,
   editAnnotation: PropTypes.func.isRequired,
+  getNextAnnotation: PropTypes.func.isRequired,
+  getPreviousAnnotation: PropTypes.func.isRequired,
+  hasNextAnnotation: PropTypes.bool.isRequired,
+  hasPrevAnnotation: PropTypes.bool.isRequired,
 };
 
 export default AnnotationDisplay;

--- a/src/components/AnnotationDisplay.jsx
+++ b/src/components/AnnotationDisplay.jsx
@@ -2,10 +2,24 @@ import React, { PropTypes } from 'react';
 import MarkdownRenderer from 'react-markdown-renderer';
 import RaisedButton from 'material-ui/RaisedButton';
 import IconButton from 'material-ui/IconButton';
-import Previous from 'material-ui/svg-icons/image/navigate-before';
-import Next from 'material-ui/svg-icons/image/navigate-next';
+import Previous from 'material-ui/svg-icons/navigation/arrow-back';
+import Next from 'material-ui/svg-icons/navigation/arrow-forward';
 
 import markdownRendererOptions from '../util/markdown-renderer-options';
+
+const styles = {
+  actionRow: {
+    alignItems: 'center',
+    display: 'flex',
+    flexFlow: 'row wrap',
+    justifyContent: 'space-between',
+  },
+  annotationViewButtons: {
+    display: 'flex',
+    flex: '0 1 auto',
+    justifyContent: 'flex-end',
+  },
+}
 
 const AnnotationDisplay = (props) => {
   const {
@@ -24,32 +38,38 @@ const AnnotationDisplay = (props) => {
         markdown={annotation}
         options={markdownRendererOptions}
       />
-      <RaisedButton
-        label="Close"
-        onTouchTap={closeAnnotation}
-        secondary
-      />
-      <RaisedButton
-        label="Edit"
-        onTouchTap={editAnnotation}
-        primary
-      />
-      <IconButton
-        disabled={hasPrevAnnotation}
-        id="previous-annotation"
-        onTouchTap={getPreviousAnnotation}
-        tooltip="View previous annotation"
-      >
-        <Previous />
-      </IconButton>
-      <IconButton
-        disabled={hasNextAnnotation}
-        id="next-annotation"
-        onTouchTap={getNextAnnotation}
-        tooltip="View next annotation"
-      >
-        <Next />
-      </IconButton>
+      <div style={styles.actionRow}>
+        <div>
+          <RaisedButton
+            label="Close"
+            onTouchTap={closeAnnotation}
+            secondary
+          />
+          <RaisedButton
+            label="Edit"
+            onTouchTap={editAnnotation}
+            primary
+          />
+        </div>
+        <div style={styles.annotationViewButtons}>
+          <IconButton
+            disabled={hasPrevAnnotation}
+            children={<Previous />}
+            id="previous-annotation"
+            onTouchTap={getPreviousAnnotation}
+            tooltip="Previous Annotation"
+            touch
+          />
+          <IconButton
+            disabled={hasNextAnnotation}
+            children={<Next />}
+            id="next-annotation"
+            onTouchTap={getNextAnnotation}
+            tooltip="Next Annotation"
+            touch
+          />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/AnnotationPanel.jsx
+++ b/src/components/AnnotationPanel.jsx
@@ -48,6 +48,10 @@ class AnnotationPanel extends React.Component {
     const {
       annotation,
       closeAnnotation,
+      getNextAnnotation,
+      getPreviousAnnotation,
+      hasNextAnnotation,
+      hasPrevAnnotation,
       lineAnnotated: {
         lineNumber,
         lineText,
@@ -70,6 +74,10 @@ class AnnotationPanel extends React.Component {
             annotation={annotation}
             closeAnnotation={closeAnnotation}
             editAnnotation={this.toggleEditState}
+            getNextAnnotation={getNextAnnotation}
+            getPreviousAnnotation={getPreviousAnnotation}
+            hasPrevAnnotation={hasPrevAnnotation}
+            hasNextAnnotation={hasNextAnnotation}
           />
         }
       </div>
@@ -82,6 +90,10 @@ AnnotationPanel.propTypes = {
   annotation: PropTypes.string.isRequired,
   closeAnnotation: PropTypes.func.isRequired,
   saveAnnotation: PropTypes.func.isRequired,
+  getNextAnnotation: PropTypes.func.isRequired,
+  getPreviousAnnotation: PropTypes.func.isRequired,
+  hasNextAnnotation: PropTypes.bool.isRequired,
+  hasPrevAnnotation: PropTypes.bool.isRequired,
   lineAnnotated: PropTypes.shape({
     lineNumber: PropTypes.number,
     lineText: PropTypes.string,

--- a/src/components/AnnotationPanel.jsx
+++ b/src/components/AnnotationPanel.jsx
@@ -83,7 +83,6 @@ class AnnotationPanel extends React.Component {
       </div>
     );
   }
-
 }
 
 AnnotationPanel.propTypes = {

--- a/src/components/AnnotationPanel.jsx
+++ b/src/components/AnnotationPanel.jsx
@@ -22,11 +22,11 @@ class AnnotationPanel extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const {
-      snippetInformation: {
+      lineAnnotated: {
         lineNumber
       },
     } = this.props
-    if (lineNumber !== nextProps.snippetInformation.lineNumber) {
+    if (lineNumber !== nextProps.lineAnnotated.lineNumber) {
       this.setState({
         isEditing: nextProps.annotation.length === 0,
       });
@@ -48,7 +48,7 @@ class AnnotationPanel extends React.Component {
     const {
       annotation,
       closeAnnotation,
-      snippetInformation: {
+      lineAnnotated: {
         lineNumber,
         lineText,
       },
@@ -82,7 +82,7 @@ AnnotationPanel.propTypes = {
   annotation: PropTypes.string.isRequired,
   closeAnnotation: PropTypes.func.isRequired,
   saveAnnotation: PropTypes.func.isRequired,
-  snippetInformation: PropTypes.shape({
+  lineAnnotated: PropTypes.shape({
     lineNumber: PropTypes.number,
     lineText: PropTypes.string,
   }).isRequired,

--- a/src/containers/Annotations.jsx
+++ b/src/containers/Annotations.jsx
@@ -31,12 +31,12 @@ export class Annotations extends React.Component {
   handleSaveAnnotation(annotation) {
     const {
       dispatch,
-      snippetInformation
+      lineAnnotated
     } = this.props;
 
     const annotationData = {
       annotation,
-      ...snippetInformation,
+      ...lineAnnotated,
     };
 
     dispatch(saveAnnotation(annotationData));
@@ -48,7 +48,7 @@ export class Annotations extends React.Component {
       annotation,
       isDisplayingAnnotation,
       readOnly,
-      snippetInformation,
+      lineAnnotated,
     } = this.props;
 
     if (!isDisplayingAnnotation) {
@@ -62,7 +62,7 @@ export class Annotations extends React.Component {
     return (
       <AnnotationPanel
         annotation={annotation}
-        snippetInformation={snippetInformation}
+        lineAnnotated={lineAnnotated}
         saveAnnotation={this.handleSaveAnnotation}
         closeAnnotation={this.handleCloseAnnotation}
       />
@@ -74,28 +74,34 @@ Annotations.propTypes = {
   annotation: PropTypes.string.isRequired,
   isDisplayingAnnotation: PropTypes.bool.isRequired,
   readOnly: PropTypes.bool.isRequired,
-  snippetInformation: PropTypes.shape({
+  lineAnnotated: PropTypes.shape({
     lineNumber: PropTypes.number,
     lineText: PropTypes.string,
   }).isRequired,
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   const {
-    isDisplayingAnnotation,
-    snippetInformation: {
-      lineNumber,
+    annotation: {
+      isDisplayingAnnotation,
+      lineAnnotated,
     },
-  } = state.annotation;
+    app: {
+      annotations,
+      readOnly,
+      snippetLanguage,
+    },
+  } = state;
+  const { lineNumber } = lineAnnotated;
   // Check that
-  const annotation = isDisplayingAnnotation ? (state.app.annotations[lineNumber] && state.app.annotations[lineNumber].annotation) || '' : '';
+  const annotation = (isDisplayingAnnotation && annotations[lineNumber] && annotations[lineNumber].annotation) || '';
   return {
-    isDisplayingAnnotation,
-    readOnly: state.app.readOnly,
-    snippetLanguage: state.app.snippetLanguage,
-    snippetInformation: state.annotation.snippetInformation,
     annotation,
-    appState: state.app,
+    annotations,
+    isDisplayingAnnotation,
+    lineAnnotated,
+    readOnly,
+    snippetLanguage,
   };
 };
 

--- a/src/containers/Annotations.jsx
+++ b/src/containers/Annotations.jsx
@@ -78,6 +78,7 @@ Annotations.propTypes = {
     lineNumber: PropTypes.number,
     lineText: PropTypes.string,
   }).isRequired,
+  snippetLanguage: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = state => {

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -285,7 +285,7 @@ const mapStateToProps = state => ({
   filters: state.app.filters,
   snippetLanguage: state.app.snippetLanguage,
   openLine: (state.annotation.isDisplayingAnnotation
-    ? state.annotation.snippetInformation.lineNumber
+    ? state.annotation.lineAnnotated.lineNumber
     : undefined),
   readOnly: state.app.readOnly,
   snippet: state.app.snippet,

--- a/src/reducers/annotation.js
+++ b/src/reducers/annotation.js
@@ -2,7 +2,7 @@ import * as actions from '../actions/annotation';
 
 export const initialState = {
   isDisplayingAnnotation: false,
-  snippetInformation: {},
+  lineAnnotated: {},
 };
 
 const annotation = (state = initialState, action) => {
@@ -11,7 +11,7 @@ const annotation = (state = initialState, action) => {
       return {
         ...state,
         isDisplayingAnnotation: true,
-        snippetInformation: action.payload,
+        lineAnnotated: action.payload,
       };
     }
     case actions.CLOSE_ANNOTATION_PANEL: {
@@ -21,7 +21,7 @@ const annotation = (state = initialState, action) => {
       return {
         ...state,
         isDisplayingAnnotation: false,
-        snippetInformation: {},
+        lineAnnotated: {},
       };
     }
     default: {

--- a/src/util/annotations.js
+++ b/src/util/annotations.js
@@ -1,0 +1,31 @@
+import _ from 'lodash';
+
+export const getAnnotatedLines = (annotations) => {
+  return _.sortBy(_.keys(annotations).map(key => Number(key)));
+};
+
+export const getPreviousAnnotation = (annotations, displayedLineNumber) => {
+  const annotatedLines = getAnnotatedLines(annotations);
+  if (_.head(annotatedLines) === displayedLineNumber) {
+    // First annotation is the one being displayed so there isn't another
+    // annotation before this one; return undefined
+    return undefined;
+  }
+  // Get the index of the currently displayed annotation in the annotatedLines
+  // array and subtract one to get index of the previous annotation
+  const index = _.sortedIndexOf(annotatedLines, displayedLineNumber) - 1;
+  return annotations[annotatedLines[index]];
+}
+
+export const getNextAnnotation = (annotations, displayedLineNumber) => {
+  const annotatedLines = getAnnotatedLines(annotations);
+  if (_.last(annotatedLines) === displayedLineNumber) {
+    // Last annotation is the one being displayed so there isn't another
+    // annotation after this one; return undefined
+    return undefined;
+  }
+  // Get the index of the currently displayed annotation in the annotatedLines
+  // array and add one to get index of the next annotation
+  const index = _.sortedIndexOf(annotatedLines, displayedLineNumber) + 1;
+  return annotations[annotatedLines[index]];
+}

--- a/src/util/annotations.js
+++ b/src/util/annotations.js
@@ -1,12 +1,18 @@
 import _ from 'lodash';
 
+export const hasPreviousAnnotation = (annotatedLines, lineNumber) =>
+  _.head(annotatedLines) === lineNumber;
+
+export const hasNextAnnotation = (annotatedLines, lineNumber) =>
+  _.last(annotatedLines) === lineNumber;
+
 export const getAnnotatedLines = (annotations) => {
   return _.sortBy(_.keys(annotations).map(key => Number(key)));
 };
 
 export const getPreviousAnnotation = (annotations, displayedLineNumber) => {
   const annotatedLines = getAnnotatedLines(annotations);
-  if (_.head(annotatedLines) === displayedLineNumber) {
+  if (hasPreviousAnnotation(annotatedLines, displayedLineNumber)) {
     // First annotation is the one being displayed so there isn't another
     // annotation before this one; return undefined
     return undefined;
@@ -19,7 +25,7 @@ export const getPreviousAnnotation = (annotations, displayedLineNumber) => {
 
 export const getNextAnnotation = (annotations, displayedLineNumber) => {
   const annotatedLines = getAnnotatedLines(annotations);
-  if (_.last(annotatedLines) === displayedLineNumber) {
+  if (hasNextAnnotation(annotatedLines, displayedLineNumber)) {
     // Last annotation is the one being displayed so there isn't another
     // annotation after this one; return undefined
     return undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds two buttons in the `AnnotationDisplay` component to view the previous/next annotation. If there isn't before/after it, the buttons will be disabled.

## Motivation and Context
Fixes #228 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.