### PR TITLE
Saving existing snippets uses key value instead of title

### DIFF
--- a/__tests__/actions/__snapshots__/app.js.snap
+++ b/__tests__/actions/__snapshots__/app.js.snap
@@ -15,3 +15,10 @@ Object {
   "type": "SELECT_ALL_FILTERS",
 }
 `;
+
+exports[`Actions: App SET_SNIPPET_KEY creates correct action object 1`] = `
+Object {
+  "payload": "szechuan sauce",
+  "type": "SET_SNIPPET_KEY",
+}
+`;

--- a/__tests__/actions/app.js
+++ b/__tests__/actions/app.js
@@ -6,6 +6,12 @@ import thunk from 'redux-thunk';
 import * as actions from '../../src/actions/app';
 
 describe('Actions: App', () => {
+  describe('SET_SNIPPET_KEY', () => {
+    it('creates correct action object', () => {
+      const key = 'szechuan sauce';
+      expect(actions.setSnippetKey(key)).toMatchSnapshot();
+    });
+  });
   describe('SET_SNIPPET_CONTENTS', () => {
     it('creates an action to set the snippet contents', () => {
       const snippet = 'Show me what you got';

--- a/__tests__/reducers/__snapshots__/app.js.snap
+++ b/__tests__/reducers/__snapshots__/app.js.snap
@@ -6,6 +6,7 @@ Object {
   "hasUnsavedChanges": false,
   "readOnly": false,
   "snippet": "",
+  "snippetKey": "",
   "snippetLanguage": "python3",
   "snippetTitle": "",
 }

--- a/__tests__/reducers/app.js
+++ b/__tests__/reducers/app.js
@@ -7,6 +7,17 @@ describe('Reducer: App', () => {
       expect(initialState).toMatchSnapshot();
     });
   });
+  it('handles SET_SNIPPET_KEY', () => {
+    const snippetKey = 'szechuan sauce';
+    const action = {
+      type: actions.SET_SNIPPET_KEY,
+      payload: snippetKey,
+    };
+    const expected = {
+      snippetKey
+    }
+    expect(reducer({}, action)).toEqual(expected);
+  });
   it('handles RESET_STATE', () => {
     const action = {
       type: actions.RESET_STATE,
@@ -17,7 +28,7 @@ describe('Reducer: App', () => {
     };
     expect(reducer(state, action)).toEqual(initialState);
   });
-  it('should handle SET_SNIPPET_CONTENTS', () => {
+  it('handles SET_SNIPPET_CONTENTS', () => {
     const snippet = 'Show me what you got';
     const action = {
       type: actions.SET_SNIPPET_CONTENTS,
@@ -30,7 +41,7 @@ describe('Reducer: App', () => {
     }
     expect(reducer(undefined, action)).toEqual(expected);
   });
-  it('should handle TOGGLE_EDITING_STATE', () => {
+  it('handles TOGGLE_EDITING_STATE', () => {
     const action = {
       type: actions.TOGGLE_EDITING_STATE,
     };
@@ -41,7 +52,7 @@ describe('Reducer: App', () => {
     };
     expect(reducer(undefined, action)).toEqual(expected);
   });
-  it('should handle SET_RULE_FILTERS', () => {
+  it('handles SET_RULE_FILTERS', () => {
     const filters = {
       'for_stmt': {
         prettyTokenName: 'For Loops',
@@ -65,7 +76,7 @@ describe('Reducer: App', () => {
     };
     expect(reducer(undefined, action)).toEqual(expected);
   });
-  it('should handle RESET_RULE_FILTERS', () => {
+  it('handles RESET_RULE_FILTERS', () => {
     const filters = {
       'for_stmt': {
         prettyTokenName: 'For Loops',
@@ -97,7 +108,7 @@ describe('Reducer: App', () => {
     };
     expect(reducer({ filters }, action)).toEqual(expected);
   });
-  it('should handle SELECT_ALL_FILTERS', () => {
+  it('handles SELECT_ALL_FILTERS', () => {
     const filters = {
       'for_stmt': {
         prettyTokenName: 'For Loops',
@@ -129,7 +140,7 @@ describe('Reducer: App', () => {
     };
     expect(reducer({ filters }, action)).toEqual(expected);
   });
-  it('should handle SET_AST', () => {
+  it('handles SET_AST', () => {
     const AST = {
       "type": "file_input",
       "begin": 0,
@@ -151,7 +162,7 @@ describe('Reducer: App', () => {
     };
     expect(reducer(undefined, action)).toEqual(expected)
   });
-  it('should handle SAVE_ANNOTATION', () => {
+  it('handles SAVE_ANNOTATION', () => {
     const annotationData = {
       annotation: 'You pass butter.',
       lineNumber: 1,
@@ -170,7 +181,7 @@ describe('Reducer: App', () => {
     };
     expect(reducer(undefined, action)).toEqual(expected);
   });
-  it('should handle RESTORE_STATE', () => {
+  it('handles RESTORE_STATE', () => {
     const savedState = {
       "snippet": "\t",
       "snippetTitle": "",
@@ -199,7 +210,7 @@ describe('Reducer: App', () => {
     };
     expect(reducer(undefined, action)).toEqual(expected);
   });
-  it('should handle SET_SNIPPET_TITLE', () => {
+  it('handles SET_SNIPPET_TITLE', () => {
     const snippetTitle = 'Get Schwifty'
     const action = {
       type: actions.SET_SNIPPET_TITLE,
@@ -212,7 +223,7 @@ describe('Reducer: App', () => {
     }
     expect(reducer(undefined, action)).toEqual(expected);
   });
-  it('should handle SET_SNIPPET_LANGUAGE', () => {
+  it('handles SET_SNIPPET_LANGUAGE', () => {
     const snippetLanguage = 'Gromflomite';
     const action = {
       type: actions.SET_SNIPPET_LANGUAGE,
@@ -225,7 +236,7 @@ describe('Reducer: App', () => {
     };
     expect(reducer(undefined, action)).toEqual(expected);
   });
-  it('should handle CLEAR_UNSAVED_CHANGES', () => {
+  it('handles CLEAR_UNSAVED_CHANGES', () => {
     const action = {
       type: actions.CLEAR_UNSAVED_CHANGES,
     };
@@ -280,7 +291,7 @@ describe('Reducer: App', () => {
       expect(reducer(undefined, action)).toEqual(expected);
     });
   });
-  it('should handle SAVE_SUCCEEDED', () => {
+  it('handles SAVE_SUCCEEDED', () => {
     const state = {
       hasUnsavedChanges: true,
     };

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -134,7 +134,7 @@ export const saveExisting = () => {
 
     // Get the app state to save (and the snippet title to save to)
     const appState = getState().app;
-    const { snippetTitle: title } = appState;
+    const { snippetKey: key } = appState;
 
     // Construct the necessary request objects
     const reqBody = JSON.stringify(appState);
@@ -145,7 +145,7 @@ export const saveExisting = () => {
     };
     dispatch(saveStarted());
     // Update the snippet
-    return axios.put(makeSaveEndpointUrl(username, title), reqBody, reqHeaders)
+    return axios.put(makeSaveEndpointUrl(username, key), reqBody, reqHeaders)
       .then(() => {
         dispatch(saveSucceeded());
       }, () => {

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -19,6 +19,12 @@ export const SET_SNIPPET_CONTENTS = 'SET_SNIPPET_CONTENTS';
 export const SET_SNIPPET_LANGUAGE = 'SET_SNIPPET_LANGUAGE';
 export const SET_SNIPPET_TITLE = 'SET_SNIPPET_TITLE';
 export const TOGGLE_EDITING_STATE = 'TOGGLE_EDITING_STATE';
+export const SET_SNIPPET_KEY = 'SET_SNIPPET_KEY';
+
+export const setSnippetKey = (key) => ({
+  type: SET_SNIPPET_KEY,
+  payload: key,
+})
 
 export const resetState = () => ({
   type: RESET_STATE,

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -10,6 +10,7 @@ import {
   saveNew,
   saveExisting,
   setSnippetContents,
+  setSnippetKey,
   setSnippetLanguage,
   setSnippetTitle,
   toggleEditState,
@@ -158,10 +159,8 @@ export class SnippetArea extends React.Component {
       .then((snippetKey) => {
         // Redirect the user to the snippet's page
         router.push(`/${username}/${snippetKey}`);
-        // Update the snippet's title if the request returned a different key
-        if (snippetTitle !== snippetKey) {
-          dispatch(setSnippetTitle(snippetKey))
-        }
+        // Update the snippet's key
+        dispatch(setSnippetKey(snippetKey))
         this.showSnackbar('Codesplaination Saved!');
       }, () => {
         this.showSnackbar('Failed to save - an error occurred');
@@ -193,10 +192,8 @@ export class SnippetArea extends React.Component {
       .then((snippetKey) => {
         // Redirect the user to the snippet's page
         router.push(`/${username}/${snippetKey}`);
-        // Update the snippet's title if the request returned a different key
-        if (title !== snippetKey) {
-          dispatch(setSnippetTitle(snippetKey));
-        }
+        // Update the snippet's key
+        dispatch(setSnippetKey(snippetKey))
         this.showSnackbar('Codesplaination Saved!');
         const permissions = {
           canRead: true,

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -11,6 +11,7 @@ export const initialState = {
   snippetLanguage: 'python3',
   readOnly: false,
   snippet: '',
+  snippetKey: '',
   snippetTitle: '',
 };
 
@@ -20,6 +21,12 @@ const app = (state = initialState, action) => {
       return {
         ...initialState,
       };
+    }
+    case actions.SET_SNIPPET_KEY: {
+      return {
+        ...state,
+        snippetKey: action.payload
+      }
     }
     case actions.SET_SNIPPET_CONTENTS: {
       return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds an action to set the snippet key in the app state. The key will be saved when saving a new snippet; if a previously-saved snippet doesn't have one, it will set it to the URL's id param. This key is then used to update a previously saved snippet, as it will use that key instead of the title, as we were doing before

## Motivation and Context
fixes #385 

## Checklist:
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed