### PR TITLE
Saving an annotation will trigger a save to S3 when snippetKey is presetn

### DIFF
--- a/__tests__/containers/Annotations.test.jsx
+++ b/__tests__/containers/Annotations.test.jsx
@@ -19,6 +19,7 @@ describe('<Annotations />', () => {
       lineAnnotated={mocklineAnnotated}
       readOnly={true}
       router={mockRouter}
+      snippetKey=""
       snippetLanguage="python3"
     />
   );

--- a/src/containers/Annotations.jsx
+++ b/src/containers/Annotations.jsx
@@ -56,7 +56,8 @@ export class Annotations extends React.Component {
   handleSaveAnnotation(annotation) {
     const {
       dispatch,
-      lineAnnotated
+      lineAnnotated,
+      snippetKey
     } = this.props;
 
     const annotationData = {
@@ -65,7 +66,10 @@ export class Annotations extends React.Component {
     };
 
     dispatch(saveAnnotation(annotationData));
-    dispatch(saveExisting());
+    // Save the snippet only if this snippet has already been saved.
+    if (snippetKey) {
+      dispatch(saveExisting());
+    }
   }
 
   getPreviousAnnotation() {
@@ -154,6 +158,7 @@ Annotations.propTypes = {
     lineNumber: PropTypes.number,
     lineText: PropTypes.string,
   }).isRequired,
+  snippetKey: PropTypes.string.isRequired,
   snippetLanguage: PropTypes.string.isRequired,
 };
 
@@ -166,6 +171,7 @@ const mapStateToProps = state => {
     app: {
       annotations,
       readOnly,
+      snippetKey,
       snippetLanguage,
     },
   } = state;
@@ -178,6 +184,7 @@ const mapStateToProps = state => {
     isDisplayingAnnotation,
     lineAnnotated,
     readOnly,
+    snippetKey,
     snippetLanguage,
   };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR refactors the `handleSaveAnnotation` method of the `Annotation` container component to add a check for the snippetKey prop. If it is non-empty, then an action will be dispatched to save the snippet state to S3. If it is empty (i.e. the snippet hasn't been saved yet) then the action to save to S3 won't be dispatched. 

## Motivation and Context
Fixes #373 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
