### PR TITLE
Refactor editModeOptions for CodeMirror to specify cursorBlinkRate

### DIFF
--- a/__tests__/components/__snapshots__/Editor.test.jsx.snap
+++ b/__tests__/components/__snapshots__/Editor.test.jsx.snap
@@ -3,6 +3,7 @@ exports[`<Editor /> matches snapshot 1`] = `
   onChange={[Function]}
   options={
     Object {
+      "cursorBlinkRate": 500,
       "gutters": Array [
         "annotations",
         "CodeMirror-linenumbers",

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -24,14 +24,15 @@ const baseCodeMirrorOptions = {
 // Options specific for edit mode should be set here
 const editModeOptions = {
   ...baseCodeMirrorOptions,
+  cursorBlinkRate: 500,
   readOnly: false,
 };
 
 // Options specific for annotation mode should be set here
 const annotationModeOptions = {
   ...baseCodeMirrorOptions,
-  readOnly: true,
   cursorBlinkRate: -1,
+  readOnly: true,
 };
 
 const makeMarker = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactors `editModeOptions` to specify the `cursorBlinkRate` property for CodeMirror, so that when the mode changes (e.g. when making a new snippet) the cursor will appear.

## Motivation and Context
Fixes #396 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.