### PR TITLE
Parser Webworker defaults to not log error messages

### DIFF
--- a/src/util/parser-error-logger.js
+++ b/src/util/parser-error-logger.js
@@ -5,7 +5,7 @@ const {
 
 let errorFn;
 
-if (NODE_ENV === 'development' && REACT_APP_ENABLE_PARSER_DEBUGGING === "true") {
+if (NODE_ENV === 'development' && REACT_APP_ENABLE_PARSER_DEBUGGING === 'true') {
   errorFn = (err) => { console.error(err); };
 } else {
   errorFn = () => {};

--- a/src/util/parser-error-logger.js
+++ b/src/util/parser-error-logger.js
@@ -1,0 +1,14 @@
+const {
+  NODE_ENV,
+  REACT_APP_ENABLE_PARSER_DEBUGGING
+} = process.env;
+
+let errorFn;
+
+if (NODE_ENV === 'development' && REACT_APP_ENABLE_PARSER_DEBUGGING === "true") {
+  errorFn = (err) => { console.error(err); };
+} else {
+  errorFn = () => {};
+}
+
+export default errorFn;

--- a/src/workers/parser.js
+++ b/src/workers/parser.js
@@ -1,11 +1,10 @@
+import { LOAD_PARSER } from '../actions/parser';
+import { PARSE_SNIPPET } from '../actions/app';
+import onError from '../util/parser-error-logger.js';
 import { getRuleCount, rules } from '../util/rules.js';
-import { LOAD_PARSER } from '../actions/parser'
-import { PARSE_SNIPPET } from '../actions/app'
 
 let parser = null;
 let parserCache = {};
-
-const onError = (err) => {console.error(err);}
 
 self.onmessage = ({ data : action }) => {
   switch (action.type) {


### PR DESCRIPTION
## Description
This PR changes the onError function that the parser uses. If the environment is `development` and the `REACT_APP_ENABLE_PARSER_DEBUGGING` env variable is set to "true", then it will log error messages; otherwise it will do nothing.

## Motivation and Context
Fixes #393

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.