### PR TITLE
Refactor LanguageSelector to be disabled when snippet is locked

### DIFF
--- a/__tests__/components/LanguageSelector.test.jsx
+++ b/__tests__/components/LanguageSelector.test.jsx
@@ -6,6 +6,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import LanguageSelector from '../../src/components/LanguageSelector';
 
 const defaultMockProps = {
+  disabled: false,
   language: 'python3',
   onChange: jest.fn(),
   style: {},
@@ -15,11 +16,36 @@ describe('<LanguageSelector />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, { context: { muiTheme } });
 
-  it('matches snapshot', () => {
-    const wrapper = shallowWithContext(
-      <LanguageSelector {...defaultMockProps}/>
-    );
-    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  describe('snapshot tests', () => {
+    it('matches snapshot when it is not disabled', () => {
+      const wrapper = shallowWithContext(
+        <LanguageSelector {...defaultMockProps}/>
+      );
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+    it('matches snapshot when it is disabled', () => {
+      const wrapper = shallowWithContext(
+        <LanguageSelector
+          {...defaultMockProps}
+          disabled
+        />
+      );
+      expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+  });
+
+  describe('prop: disabled', () => {
+    it('is forwarded to SelectField', () => {
+      const disabled = false;
+      const wrapper = shallowWithContext(
+        <LanguageSelector
+          {...defaultMockProps}
+          disabled={disabled}
+        />
+      );
+      const select = wrapper.find('SelectField');
+      expect(select.prop('disabled')).toEqual(disabled);
+    });
   });
 
   describe('prop: language', () => {

--- a/__tests__/components/SnippetAreaToolbar.test.jsx
+++ b/__tests__/components/SnippetAreaToolbar.test.jsx
@@ -84,7 +84,7 @@ describe('<SnippetAreaToolbar />', () => {
   });
 
   describe('prop: onSaveClick', () => {
-    it('forwarded to the SaveMenu', () => {
+    it('is forwarded to the SaveMenu', () => {
       const onSaveClick = jest.fn();
       const wrapper = shallowWithContext(
         <SnippetAreaToolbar
@@ -97,7 +97,7 @@ describe('<SnippetAreaToolbar />', () => {
   });
 
   describe('prop: onSaveAsClick', () => {
-    it('forwarded to the SaveMenu', () => {
+    it('is forwarded to the SaveMenu', () => {
       const onSaveAsClick = jest.fn();
       const wrapper = shallowWithContext(
         <SnippetAreaToolbar
@@ -106,6 +106,29 @@ describe('<SnippetAreaToolbar />', () => {
         />
       );
       expect(wrapper.find('SaveMenu').prop('onSaveAsClick')).toBe(onSaveAsClick);
+    });
+  });
+
+  describe('prop: readOnly', () => {
+    it('is forwarded to the LockButton', () => {
+      const readOnly = false;
+      const wrapper = shallowWithContext(
+        <SnippetAreaToolbar
+          {...defaultProps}
+          readOnly={readOnly}
+        />
+      );
+      expect(wrapper.find('LockButton').prop('readOnly')).toBe(readOnly);
+    });
+    it('is forwarded to the LanguageSelector\'s disabled prop', () => {
+      const readOnly = false;
+      const wrapper = shallowWithContext(
+        <SnippetAreaToolbar
+          {...defaultProps}
+          readOnly={readOnly}
+        />
+      );
+      expect(wrapper.find('LanguageSelector').prop('disabled')).toBe(readOnly);
     });
   });
 });

--- a/__tests__/components/__snapshots__/LanguageSelector.test.jsx.snap
+++ b/__tests__/components/__snapshots__/LanguageSelector.test.jsx.snap
@@ -1,4 +1,45 @@
-exports[`<LanguageSelector /> matches snapshot 1`] = `
+exports[`<LanguageSelector /> snapshot tests matches snapshot when it is disabled 1`] = `
+<SelectField
+  autoWidth={false}
+  disabled={true}
+  fullWidth={false}
+  id="languageSelector"
+  multiple={false}
+  onChange={[Function]}
+  style={Object {}}
+  value="python3">
+  <MenuItem
+    anchorOrigin={
+      Object {
+        "horizontal": "right",
+        "vertical": "top",
+      }
+    }
+    checked={false}
+    desktop={false}
+    disabled={false}
+    focusState="none"
+    insetChildren={false}
+    primaryText="Python 3"
+    value="python3" />
+  <MenuItem
+    anchorOrigin={
+      Object {
+        "horizontal": "right",
+        "vertical": "top",
+      }
+    }
+    checked={false}
+    desktop={false}
+    disabled={true}
+    focusState="none"
+    insetChildren={false}
+    primaryText="Java"
+    value="java" />
+</SelectField>
+`;
+
+exports[`<LanguageSelector /> snapshot tests matches snapshot when it is not disabled 1`] = `
 <SelectField
   autoWidth={false}
   disabled={false}

--- a/__tests__/components/__snapshots__/SnippetAreaToolbar.test.jsx.snap
+++ b/__tests__/components/__snapshots__/SnippetAreaToolbar.test.jsx.snap
@@ -34,6 +34,7 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is no
     underlineShow={true}
     value="" />
   <LanguageSelector
+    disabled={false}
     language="python"
     onChange={[Function]}
     style={
@@ -109,6 +110,7 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is re
     underlineShow={true}
     value="" />
   <LanguageSelector
+    disabled={true}
     language="python"
     onChange={[Function]}
     style={

--- a/src/components/LanguageSelector.jsx
+++ b/src/components/LanguageSelector.jsx
@@ -6,6 +6,7 @@ import {
 
 const LanguageSelector = (props) => {
   const {
+    disabled,
     language,
     onChange,
     style,
@@ -13,6 +14,7 @@ const LanguageSelector = (props) => {
 
   return (
     <SelectField
+      disabled={disabled}
       id="languageSelector"
       onChange={onChange}
       style={style}
@@ -25,6 +27,7 @@ const LanguageSelector = (props) => {
 }
 
 LanguageSelector.propTypes = {
+  disabled: PropTypes.bool.isRequired,
   language: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   style: PropTypes.object,

--- a/src/components/SnippetAreaToolbar.jsx
+++ b/src/components/SnippetAreaToolbar.jsx
@@ -62,9 +62,10 @@ const SnippetAreaToolbar = (props) => {
         value={title}
       />
       <LanguageSelector
+        disabled={readOnly}
+        language={language}
         onChange={onLanguageChange}
         style={styles.toolbarField}
-        language={language}
       />
       <LockButton
         id="lockButton"


### PR DESCRIPTION
## Description
This PR refactors the `LanguageSelector` and `SnippetAreaToolbar` components to disable selecting a language when a snippet has been locked. The `SnippetAreaToolbar` will pass its `readOnly` prop to its child `LanguageSelector`, which will then forward that to its underlying `SelectField` element.

## Motivation and Context
Fixes #395 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.