### PR TITLE
Handle users who have no index.json

### DIFF
--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -43,8 +43,8 @@ export const updateUserSnippets = () => {
       .then(res => {
         // Jump to catch block if the user has no index.json file:
         if (res.data.includes(
-          '<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message>')
-        ) {
+          '<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message>'
+        )) {
           throw new Error(`index.json does not exist for ${username}!`);
         }
 

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -40,12 +40,20 @@ export const updateUserSnippets = () => {
     };
     dispatch(updateUserSnippetsStarted());
     return axios.get(makeSaveEndpointUrl(username), { headers })
-      .then(
-        res => {
-          dispatch(setUserSnippets(res.data));
-          dispatch(updateUserSnippetsSucceeded());
-        },
-        err => dispatch(updateUserSnippetsFailed())
-      );
+      .then(res => {
+        // Jump to catch block if the user has no index.json file:
+        if (res.data.includes(
+          '<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message>')
+        ) {
+          throw new Error(`index.json does not exist for ${username}!`);
+        }
+
+        // Otherwise they have an index.json, so update their snippets
+        dispatch(setUserSnippets(res.data));
+        dispatch(updateUserSnippetsSucceeded());
+      })
+      .catch(err => {
+        dispatch(updateUserSnippetsFailed())
+      });
   };
 };

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -42,7 +42,8 @@ export const updateUserSnippets = () => {
     return axios.get(makeSaveEndpointUrl(username), { headers })
       .then(res => {
         // Jump to catch block if the user has no index.json file:
-        if (res.data.includes(
+        if (typeof(res.data) === 'string' &&
+            res.data.includes(
           '<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message>'
         )) {
           throw new Error(`index.json does not exist for ${username}!`);

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -3,12 +3,16 @@ import cookie from 'react-cookie';
 
 import { makeSaveEndpointUrl } from '../util/requests';
 
+// Util func to check for 'NoSuchKey' responses from S3
+const noSuchKey = (data) => (
+  typeof(data) === 'string' && data.includes('NoSuchKey')
+);
+
 export const SET_USER_SNIPPETS = 'SET_USER_SNIPPETS';
 export const UPDATE_USER_SNIPPETS_STARTED = 'UPDATE_USER_SNIPPETS_STARTED';
 export const UPDATE_USER_SNIPPETS_SUCCEEDED = 'UPDATE_USER_SNIPPETS_SUCCEEDED';
 export const UPDATE_USER_SNIPPETS_FAILED = 'UPDATE_USER_SNIPPETS_FAILED';
 export const UPDATE_USER_SNIPPETS = 'UPDATE_USER_SNIPPETS';
-
 
 export const setUserSnippets = (snippetMeta) => ({
   type: SET_USER_SNIPPETS,
@@ -42,10 +46,7 @@ export const updateUserSnippets = () => {
     return axios.get(makeSaveEndpointUrl(username), { headers })
       .then(res => {
         // Jump to catch block if the user has no index.json file:
-        if (typeof(res.data) === 'string' &&
-            res.data.includes(
-          '<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message>'
-        )) {
+        if (noSuchKey(res.data)) {
           throw new Error(`index.json does not exist for ${username}!`);
         }
 

--- a/src/components/menus/SnippetList.jsx
+++ b/src/components/menus/SnippetList.jsx
@@ -5,7 +5,7 @@ import { MenuItem } from 'material-ui';
 import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right';
 
 const makeMenuItems = _.memoize((userSnippets, onClick) => {
-  if (!Object.keys(userSnippets).length === 0) return null;
+  if (!Object.keys(userSnippets).length) return null;
   return Object.keys(userSnippets).map(key => (
     <MenuItem
       key={key}
@@ -16,11 +16,13 @@ const makeMenuItems = _.memoize((userSnippets, onClick) => {
 });
 
 const SnippetList = ({ titles, onClick }) => {
+  const menuItems = makeMenuItems(titles, onClick);
   return (
     <MenuItem
       primaryText="My Snippets"
       rightIcon={<ArrowDropRight />}
-      menuItems={makeMenuItems(titles, onClick)}
+      disabled={menuItems ? false : true}
+      menuItems={menuItems}
     />
   );
 };

--- a/src/components/menus/SnippetList.jsx
+++ b/src/components/menus/SnippetList.jsx
@@ -5,7 +5,7 @@ import { MenuItem } from 'material-ui';
 import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right';
 
 const makeMenuItems = _.memoize((userSnippets, onClick) => {
-  if (!Object.keys(userSnippets).length) return null;
+  if (Object.keys(userSnippets).length === 0) return null;
   return Object.keys(userSnippets).map(key => (
     <MenuItem
       key={key}

--- a/src/components/menus/SnippetList.jsx
+++ b/src/components/menus/SnippetList.jsx
@@ -21,7 +21,7 @@ const SnippetList = ({ titles, onClick }) => {
     <MenuItem
       primaryText="My Snippets"
       rightIcon={<ArrowDropRight />}
-      disabled={menuItems ? false : true}
+      disabled={!menuItems}
       menuItems={menuItems}
     />
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR causes an error to be thrown if a GET for a user's `index.json` returns a response containing this xml:
```xml
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message>
```
and the user's snippet list menu option is disabled until they possess snippet(s) & an index file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #411. This PR solves the problem of users with no `index.json` getting an infinite empty list of snippets.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots:
### User with no snippets
<img width="400" alt="screen shot 2017-04-17 at 6 07 29 pm" src="https://cloud.githubusercontent.com/assets/10351828/25108155/85341518-2399-11e7-81f8-674ecc07fba5.png">

### User with snippets
<img width="400" alt="screen shot 2017-04-17 at 6 08 01 pm" src="https://cloud.githubusercontent.com/assets/10351828/25108154/8531d3c0-2399-11e7-9f39-b15fdb1ffbe9.png">

