### PR TITLE
Refactor Auth to dispatch thunks to authorize users with Github

### DIFF
--- a/__tests__/actions/user.js
+++ b/__tests__/actions/user.js
@@ -7,13 +7,13 @@ import * as actions from '../../src/actions/user';
 
 describe('Actions: User', () => {
   describe('action creators', () => {
-    it('creates correct SAVE_ACCESS_TOKEN object', () => {
+    it('creates correct SAVE_USERNAME object', () => {
       const token = 'token';
       const expected = {
-        type: actions.SAVE_ACCESS_TOKEN,
+        type: actions.SAVE_USERNAME,
         payload: token,
       };
-      expect(actions.saveAccessToken(token)).toEqual(expected);
+      expect(actions.saveUsername(token)).toEqual(expected);
     });
     it('creates correct SAVE_ACCESS_TOKEN object', () => {
       const token = 'token';

--- a/__tests__/actions/user.js
+++ b/__tests__/actions/user.js
@@ -6,6 +6,30 @@ import thunk from 'redux-thunk';
 import * as actions from '../../src/actions/user';
 
 describe('Actions: User', () => {
+  describe('action creators', () => {
+    it('creates correct SAVE_ACCESS_TOKEN object', () => {
+      const token = 'token';
+      const expected = {
+        type: actions.SAVE_ACCESS_TOKEN,
+        payload: token,
+      };
+      expect(actions.saveAccessToken(token)).toEqual(expected);
+    });
+    it('creates correct SAVE_ACCESS_TOKEN object', () => {
+      const token = 'token';
+      const expected = {
+        type: actions.SAVE_ACCESS_TOKEN,
+        payload: token,
+      };
+      expect(actions.saveAccessToken(token)).toEqual(expected);
+    });
+    it('creates correct CLEAR_USER_CREDENTIALS object', () => {
+      const expected = {
+        type: actions.CLEAR_USER_CREDENTIALS
+      };
+      expect(actions.clearUserCredentials()).toEqual(expected);
+    });
+  });
   describe('async actions', () => {
     const middlewares = [ thunk ];
     const mockStore   = configureMockStore(middlewares);

--- a/__tests__/components/Auth.test.jsx
+++ b/__tests__/components/Auth.test.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { shallow, mount } from 'enzyme';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import toJson, { shallowToJson } from 'enzyme-to-json';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import moxios from 'moxios'
@@ -8,8 +11,11 @@ import injectTapEventPlugin from 'react-tap-event-plugin';
 // http://stackoverflow.com/a/34015469/988941
 injectTapEventPlugin();
 
-import { Auth, errors } from '../../src/components/Auth';
+import { Auth, ConnectedAuth, errors } from '../../src/components/Auth';
 import Alert from '../../src/components/Alert';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
 
 describe('<Auth />', () => {
   const muiTheme = getMuiTheme();
@@ -40,8 +46,11 @@ describe('<Auth />', () => {
           query: 'badcode',
         },
       };
+      const store = mockStore({});
       const wrapper = mountWithContext(
-        <Auth router={mockRouter} />
+        <Provider store={store}>
+          <ConnectedAuth router={mockRouter} />
+        </Provider>
       );
       moxios.wait(() => {
         const request = moxios.requests.mostRecent();
@@ -62,8 +71,11 @@ describe('<Auth />', () => {
           query: 'badcode',
         },
       };
+      const store = mockStore({});
       const wrapper = mountWithContext(
-        <Auth router={mockRouter} />
+        <Provider store={store}>
+          <ConnectedAuth router={mockRouter} />
+        </Provider>
       );
       moxios.wait(() => {
         const request = moxios.requests.mostRecent();

--- a/__tests__/reducers/__snapshots__/user.js.snap
+++ b/__tests__/reducers/__snapshots__/user.js.snap
@@ -1,0 +1,7 @@
+exports[`Reducer: User initialState should match snapshot 1`] = `
+Object {
+  "token": "",
+  "userSnippets": Object {},
+  "username": "",
+}
+`;

--- a/__tests__/reducers/user.js
+++ b/__tests__/reducers/user.js
@@ -1,10 +1,47 @@
 import * as actions from '../../src/actions/user';
-import reducer from '../../src/reducers/user';
+import reducer, { initialState } from '../../src/reducers/user';
 
 describe('Reducer: User', () => {
-  it('shoud have initial state', () => {
-    const initial = {};
-    expect(reducer(undefined, {})).toEqual(initial);
+  describe('initialState', () => {
+    it('should match snapshot', () => {
+      expect(reducer(undefined, {})).toMatchSnapshot();
+    });
+  });
+
+  it('handles SAVE_USERNAME', () => {
+    const username = 'username';
+    const action = {
+      type: actions.SAVE_USERNAME,
+      payload: username,
+    };
+    const expected = {
+      username,
+    };
+    expect(reducer({}, action)).toEqual(expected);
+  });
+
+  it('handles SAVE_ACCESS_TOKEN', () => {
+    const token = 'token';
+    const action = {
+      type: actions.SAVE_ACCESS_TOKEN,
+      payload: token,
+    };
+    const expected = {
+      token,
+    };
+    expect(reducer({}, action)).toEqual(expected);
+  });
+
+  it('handles CLEAR_USER_CREDENTIALS', () => {
+    const action = {
+      type: actions.CLEAR_USER_CREDENTIALS,
+    };
+    const state = {
+      token: 'token',
+      username: 'username',
+      snippets: {},
+    };
+    expect(reducer(state, action)).toEqual(initialState);
   });
 
   it('should handle SET_USER_SNIPPETS', () => {

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -157,3 +157,15 @@ export const saveExisting = () => {
       });
   };
 };
+
+export const loadSnippet = (snippetKey) => (dispatch, getState) => {
+  const { token, username } = getState().user;
+  const reqHeaders = {
+    Authorization: `token ${token}`,
+  };
+  return axios({
+    method: 'GET',
+    url: makeSaveEndpointUrl(username, snippetKey),
+    headers: reqHeaders,
+  });
+};

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -161,7 +161,7 @@ export const saveExisting = () => {
 export const loadSnippet = (snippetKey) => (dispatch, getState) => {
   const { token, username } = getState().user;
   const reqHeaders = {
-    Authorization: `token ${token}`,
+    Authorization: token,
   };
   return axios({
     method: 'GET',

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -3,6 +3,8 @@ import cookie from 'react-cookie';
 
 import { makeSaveEndpointUrl } from '../util/requests';
 
+const API_URL = process.env.REACT_APP_API_URL;
+
 // Util func to check for 'NoSuchKey' responses from S3
 const noSuchKey = (data) => (
   typeof(data) === 'string' && data.includes('NoSuchKey')
@@ -13,6 +15,23 @@ export const UPDATE_USER_SNIPPETS_STARTED = 'UPDATE_USER_SNIPPETS_STARTED';
 export const UPDATE_USER_SNIPPETS_SUCCEEDED = 'UPDATE_USER_SNIPPETS_SUCCEEDED';
 export const UPDATE_USER_SNIPPETS_FAILED = 'UPDATE_USER_SNIPPETS_FAILED';
 export const UPDATE_USER_SNIPPETS = 'UPDATE_USER_SNIPPETS';
+export const SAVE_USERNAME = 'SAVE_USERNAME';
+export const SAVE_ACCESS_TOKEN = 'SAVE_ACCESS_TOKEN';
+export const CLEAR_USER_CREDENTIALS = 'CLEAR_USER_CREDENTIALS';
+
+export const saveUsername = (username) => ({
+  type: SAVE_USERNAME,
+  payload: username,
+});
+
+export const saveAccessToken = (accessToken) => ({
+  type: SAVE_ACCESS_TOKEN,
+  payload: accessToken,
+});
+
+export const clearUserCredentials = () => ({
+  type: CLEAR_USER_CREDENTIALS,
+});
 
 export const setUserSnippets = (snippetMeta) => ({
   type: SET_USER_SNIPPETS,
@@ -58,4 +77,27 @@ export const updateUserSnippets = () => {
         dispatch(updateUserSnippetsFailed())
       });
   };
+};
+
+export const fetchAccessToken = (authCode) => (dispatch) => {
+  const reqUrl = `${API_URL}/auth`;
+  const reqBody = { code: authCode };
+  return axios({
+    method: 'POST',
+    url: reqUrl,
+    data: reqBody,
+  });
+}
+
+export const fetchUserInfo = () => (dispatch, getState) => {
+  const { token } = getState().user;
+  const reqHeaders = {
+    Accept: 'application/json',
+    Authorization: `token ${token}`,
+  };
+  return axios({
+    method: 'GET',
+    url: 'https://api.github.com/user',
+    headers: reqHeaders,
+  });
 };

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -91,6 +91,7 @@ export const fetchAccessToken = (authCode) => (dispatch) => {
 }
 
 export const fetchUserInfo = () => (dispatch, getState) => {
+  console.log('getState()', getState());
   const { token } = getState().user;
   const reqHeaders = {
     Accept: 'application/json',

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -18,6 +18,7 @@ export const UPDATE_USER_SNIPPETS = 'UPDATE_USER_SNIPPETS';
 export const SAVE_USERNAME = 'SAVE_USERNAME';
 export const SAVE_ACCESS_TOKEN = 'SAVE_ACCESS_TOKEN';
 export const CLEAR_USER_CREDENTIALS = 'CLEAR_USER_CREDENTIALS';
+export const RESTORE_USER_CREDENTIALS = 'RESTORE_USER_CREDENTIALS';
 
 export const saveUsername = (username) => ({
   type: SAVE_USERNAME,
@@ -101,3 +102,11 @@ export const fetchUserInfo = () => (dispatch, getState) => {
     headers: reqHeaders,
   });
 };
+
+export const restoreUserCredentials = (token, username) => ({
+  type: RESTORE_USER_CREDENTIALS,
+  payload: {
+    token,
+    username,
+  },
+})

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -51,7 +51,6 @@ export class Auth extends React.Component {
   componentDidMount() {
     // Extract the code provided by GitHub from the redirect query string
     const { code } = this.props.router.location.query;
-    // this.runLoginSequence(code);
     this.login(code);
   }
 

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import cookie from 'react-cookie';
-import axios from 'axios';
+import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
+import {
+  fetchAccessToken,
+  saveAccessToken,
+  fetchUserInfo,
+  saveUsername,
+} from '../actions/user';
 import Loading from '../components/Loading';
 import Alert from '../components/Alert';
 
-const API_URL = process.env.REACT_APP_API_URL;
 export const errors = {
   badCode: "Failed to login with GitHub, sorry.",
   badOrg: "Sorry, you are not a member of an organization authorized to use" +
@@ -36,71 +41,43 @@ user is redirected to the URL they attempted to login from initially.
 export class Auth extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { waiting: true };
+    this.state = {
+      waiting: true,
+    };
+    this.login = this.login.bind(this);
     this.redirectUser = this.redirectUser.bind(this);
-    this.runLoginSequence = this.runLoginSequence.bind(this);
-    this.fetchAccessToken = this.fetchAccessToken.bind(this);
-    this.fetchUserInfo = this.fetchUserInfo.bind(this);
   }
 
   componentDidMount() {
     // Extract the code provided by GitHub from the redirect query string
     const { code } = this.props.router.location.query;
-    this.runLoginSequence(code);
+    // this.runLoginSequence(code);
+    this.login(code);
   }
 
-  async runLoginSequence(authCode) {
-    // Use authorization code to get access token from API
-    const token = await this.fetchAccessToken(authCode);
-    if (!token) {
-      return;
-    }
-
-    // Now get their username, and save other basic info to cookies
-    const username = await this.fetchUserInfo(token);
-    if (!username) {
-      return;
-    }
-  }
-
-  // Returns access token if successful, otherwise returns undefined
-  async fetchAccessToken(authCode) {
-    let res;
-    try {
-      res = await axios.post(`${API_URL}/auth`, { code: authCode });
-    } catch(err) {
-      const error = resolveErrorMessage(err.response.status);
-      this.setState({ waiting: false, error });
-      return;
-    }
-
-    // Code was accepted, so extract and save the token from the response
-    const { token } = res.data;
-    cookie.save('token', token, { path: '/' });
-    return token;
-  }
-
-  // Returns username if successful, otherwise returns undefined
-  async fetchUserInfo(token) {
-    // Get the user's basic info
-    let res;
-    try {
-      const headers = {
-        Accept: 'application/json',
-        Authorization: `token ${token}`,
-      };
-      res = await axios.get('https://api.github.com/user', { headers });
-    } catch(err) {
-      const error = resolveErrorMessage(err.response.status);
-      this.setState({ waiting: false, error });
-      return;
-    }
-    // Can pull lots of other stuff out of res.data if needed
-    const { login, avatar_url } = res.data;
-    cookie.save('userAvatarURL', avatar_url, { path: '/' });
-    cookie.save('username', login, { path: '/' });
-    this.setState({ waiting: false });
-    return login;
+  login(authCode) {
+    const { dispatch } = this.props;
+    dispatch(fetchAccessToken(authCode))
+      .then((res) => {
+        const { token } = res.data;
+        dispatch(saveAccessToken(token));
+        cookie.save('token', token, { path: '/' });
+      })
+      .then(() => dispatch(fetchUserInfo()))
+      .then((res) => {
+        const { login: username, avatar_url: userAvatarURL } = res.data;
+        dispatch(saveUsername(username));
+        cookie.save('userAvatarURL', userAvatarURL, { path: '/' });
+        cookie.save('username', username, { path: '/' });
+        this.setState({ waiting: false });
+      })
+      .catch((err) => {
+        const errorMessage = resolveErrorMessage(err.response.status);
+        this.setState({
+          error: errorMessage,
+          waiting: false,
+        });
+      });
   }
 
   redirectUser() {
@@ -141,4 +118,6 @@ export class Auth extends React.Component {
   }
 }
 
-export default withRouter(Auth);
+export const ConnectedAuth = connect()(Auth);
+
+export default withRouter(ConnectedAuth);

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -13,7 +13,8 @@ import {
   restoreState,
 } from '../actions/app';
 import { setPermissions } from '../actions/permissions';
-import { removeDeprecatedFiltersFromState } from '../util/rules';
+import { restoreUserCredentials } from '../actions/user';
+import { removeDeprecatedFiltersFromState } from '../util/codemirror-utils';
 import { setDefaults } from '../util/state-management';
 
 const styles = {
@@ -56,6 +57,8 @@ export class AppBody extends Component {
       }
       return;
     }
+
+    dispatch(restoreUserCredentials(cookie.load('token'), cookie.load('username')));
 
     dispatch(loadSnippet(snippetKey))
       .then(res => {

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -58,9 +58,10 @@ export class CodesplainAppBar extends React.Component {
 
   handleSnippetSelected(key) {
     const username  = cookie.load('username');
+    console.log(username);
     window.location = `/${username}/${key}`;
-    const { router } = this.props;
-    router.push(`/${username}/${key}`)
+    // const { router } = this.props;
+    // router.push(`/${username}/${key}`)
   }
 
   onLoginClick() {

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -58,10 +58,7 @@ export class CodesplainAppBar extends React.Component {
 
   handleSnippetSelected(key) {
     const username  = cookie.load('username');
-    console.log(username);
     window.location = `/${username}/${key}`;
-    // const { router } = this.props;
-    // router.push(`/${username}/${key}`)
   }
 
   onLoginClick() {

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -119,7 +119,7 @@ export class SnippetArea extends React.Component {
   }
 
   handleSave() {
-    // Make sure title is populated
+
     const {
       dispatch,
       router,
@@ -128,9 +128,10 @@ export class SnippetArea extends React.Component {
 
     const { id } = router.params;
 
+    // Make sure title is populated
     if (!snippetTitle) {
       this.setState({ titleErrorText: 'This field is required' });
-      this.showSnackbar('Please populate the title field before saving.');
+      this.showSnackbar('Please enter a Snippet Name.');
       return;
     }
     this.setState({ titleErrorText: '' });

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -33,7 +33,6 @@ export default (state = initialState, action) => {
       };
     }
     case actions.CLEAR_USER_CREDENTIALS: {
-
       return {
         ...initialState
       };

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -14,6 +14,12 @@ export default (state = initialState, action) => {
         userSnippets: action.payload,
       }
     }
+    case actions.RESTORE_USER_CREDENTIALS: {
+      return {
+        ...state,
+        ...action.payload,
+      }
+    }
     case actions.SAVE_USERNAME: {
       return {
         ...state,

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,6 +1,12 @@
 import * as actions from '../actions/user';
 
-const user = (state = {}, action) => {
+export const initialState = {
+  token: '',
+  username: '',
+  userSnippets: {},
+};
+
+export default (state = initialState, action) => {
   switch (action.type) {
     case actions.SET_USER_SNIPPETS: {
       return {
@@ -8,10 +14,26 @@ const user = (state = {}, action) => {
         userSnippets: action.payload,
       }
     }
+    case actions.SAVE_USERNAME: {
+      return {
+        ...state,
+        username: action.payload,
+      };
+    }
+    case actions.SAVE_ACCESS_TOKEN: {
+      return {
+        ...state,
+        token: action.payload,
+      };
+    }
+    case actions.CLEAR_USER_CREDENTIALS: {
+
+      return {
+        ...initialState
+      };
+    }
     default: {
       return state;
     }
   }
 };
-
-export default user;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR refactors the `Auth` component to dispatch thunks to authorize a user with Github. Previously we would make AJAX requests directly on the component; instead the requests become abstracted away from the component, and simplifies the logic of logging in a user

This PR also refactors `AppBody` to similarly dispatch a thunk instead of directly making a request

## Motivation and Context
Fixes #349 
Fixes #363 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.