### PR TITLE
Refactor CodesplainAppbar to make only Codesplain text redirect to home

### DIFF
--- a/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
+++ b/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
@@ -7,14 +7,18 @@ exports[`<CodesplainAppBar /> snapshot tests user is logged in 1`] = `
         onTitleClicked={[Function]}
         snippetTitles={Array []} />
     }
-    onTitleTouchTap={[Function]}
     showMenuIconButton={false}
-    style={
-      Object {
-        "cursor": "pointer",
-      }
+    title={
+      <span
+        onClick={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+          }
+        }>
+        Codesplain
+      </span>
     }
-    title="Codesplain"
     zDepth={1} />
   <Dialog
     actions={
@@ -65,14 +69,18 @@ exports[`<CodesplainAppBar /> snapshot tests user is not logged in 1`] = `
       <LoginButton
         onClick={[Function]} />
     }
-    onTitleTouchTap={[Function]}
     showMenuIconButton={false}
-    style={
-      Object {
-        "cursor": "pointer",
-      }
+    title={
+      <span
+        onClick={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+          }
+        }>
+        Codesplain
+      </span>
     }
-    title="Codesplain"
     zDepth={1} />
   <Dialog
     actions={

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -145,14 +145,20 @@ export class CodesplainAppBar extends React.Component {
       <LoginButton
         onClick={this.onLoginClick}
       />;
+    const titleElement = (
+      <span
+        onClick={this.handleTitleTouchTap}
+        style={styles.title}
+      >
+        Codesplain
+      </span>
+    );
 
     return (
       <div>
         <AppBar
           showMenuIconButton={false}
-          title="Codesplain"
-          style={styles.title}
-          onTitleTouchTap={this.handleTitleTouchTap}
+          title={titleElement}
           iconElementRight={rightElement}
         />
         <Dialog


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR modifies the title element passed to `AppBar`'s `title` prop, so that it is passed a `<span />` instead of a string, with the span having the event handler attached to it

## Motivation and Context
Fixes #397

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.