### PR TITLE
Fix bug with using saved username to load a snippet

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -154,8 +154,8 @@ export const saveExisting = () => (dispatch, getState) => {
       });
 };
 
-export const loadSnippet = (snippetKey) => (dispatch, getState) => {
-  const { token, username } = getState().user;
+export const loadSnippet = (username, snippetKey) => (dispatch, getState) => {
+  const { token } = getState().user;
   const reqHeaders = {
     Authorization: token,
   };

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -58,9 +58,10 @@ export class AppBody extends Component {
       return;
     }
 
+    // Restore the user's credentials into state
     dispatch(restoreUserCredentials(cookie.load('token'), cookie.load('username')));
 
-    dispatch(loadSnippet(snippetKey))
+    dispatch(loadSnippet(username, snippetKey))
       .then((res) => {
         // Normalize the app state received from S3
         const appState = setDefaults(removeDeprecatedFiltersFromState(res.data));


### PR DESCRIPTION
## Description
Fixes `loadSnippet` action to use the username from the router params instead of the saved username in state

## Motivation and Context
No issue number. Needed because currently you can view only your own snippets

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
