### PR TITLE
Refactor SnippetAreaToolbar to group LockButton and SaveMenu together

### DIFF
--- a/__tests__/components/__snapshots__/SnippetAreaToolbar.test.jsx.snap
+++ b/__tests__/components/__snapshots__/SnippetAreaToolbar.test.jsx.snap
@@ -45,31 +45,33 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is no
         "verticalAlign": "middle",
       }
     } />
-  <LockButton
-    onClick={[Function]}
-    readOnly={false}
-    style={
-      Object {
-        "flexBasis": "auto",
-        "flexGrow": "1",
-        "flexShrink": "1",
-        "verticalAlign": "middle",
-      }
-    } />
-  <SaveMenu
-    canSave={true}
-    enabled={true}
-    id="saveMenu"
-    onSaveAsClick={[Function]}
-    onSaveClick={[Function]}
-    style={
-      Object {
-        "flexBasis": "auto",
-        "flexGrow": "1",
-        "flexShrink": "1",
-        "verticalAlign": "middle",
-      }
-    } />
+  <div>
+    <LockButton
+      onClick={[Function]}
+      readOnly={false}
+      style={
+        Object {
+          "flexBasis": "auto",
+          "flexGrow": "1",
+          "flexShrink": "1",
+          "verticalAlign": "middle",
+        }
+      } />
+    <SaveMenu
+      canSave={true}
+      enabled={true}
+      id="saveMenu"
+      onSaveAsClick={[Function]}
+      onSaveClick={[Function]}
+      style={
+        Object {
+          "flexBasis": "auto",
+          "flexGrow": "1",
+          "flexShrink": "1",
+          "verticalAlign": "middle",
+        }
+      } />
+  </div>
 </div>
 `;
 
@@ -120,30 +122,32 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is re
         "verticalAlign": "middle",
       }
     } />
-  <LockButton
-    onClick={[Function]}
-    readOnly={true}
-    style={
-      Object {
-        "flexBasis": "auto",
-        "flexGrow": "1",
-        "flexShrink": "1",
-        "verticalAlign": "middle",
-      }
-    } />
-  <SaveMenu
-    canSave={true}
-    enabled={true}
-    id="saveMenu"
-    onSaveAsClick={[Function]}
-    onSaveClick={[Function]}
-    style={
-      Object {
-        "flexBasis": "auto",
-        "flexGrow": "1",
-        "flexShrink": "1",
-        "verticalAlign": "middle",
-      }
-    } />
+  <div>
+    <LockButton
+      onClick={[Function]}
+      readOnly={true}
+      style={
+        Object {
+          "flexBasis": "auto",
+          "flexGrow": "1",
+          "flexShrink": "1",
+          "verticalAlign": "middle",
+        }
+      } />
+    <SaveMenu
+      canSave={true}
+      enabled={true}
+      id="saveMenu"
+      onSaveAsClick={[Function]}
+      onSaveClick={[Function]}
+      style={
+        Object {
+          "flexBasis": "auto",
+          "flexGrow": "1",
+          "flexShrink": "1",
+          "verticalAlign": "middle",
+        }
+      } />
+  </div>
 </div>
 `;

--- a/src/components/SnippetAreaToolbar.jsx
+++ b/src/components/SnippetAreaToolbar.jsx
@@ -67,19 +67,21 @@ const SnippetAreaToolbar = (props) => {
         onChange={onLanguageChange}
         style={styles.toolbarField}
       />
-      <LockButton
-        onClick={onLockClick}
-        readOnly={readOnly}
-        style={styles.buttons}
-      />
-      <SaveMenu
-        canSave={canSave}
-        enabled={saveEnabled}
-        id="saveMenu"
-        onSaveAsClick={onSaveAsClick}
-        onSaveClick={onSaveClick}
-        style={styles.buttons}
-      />
+      <div>
+        <LockButton
+          onClick={onLockClick}
+          readOnly={readOnly}
+          style={styles.buttons}
+        />
+        <SaveMenu
+          canSave={canSave}
+          enabled={saveEnabled}
+          id="saveMenu"
+          onSaveAsClick={onSaveAsClick}
+          onSaveClick={onSaveClick}
+          style={styles.buttons}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR refactors the `SnippetAreaToolbar` to wrap the `LockButton` and `SaveMenu` in a div element to group them together so they aren't separated when the browser window resizes

## Motivation and Context
Fixes #388 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
