### PR TITLE
Add org propType, refactor SnippetArea propTypes and mapStateToProps

### DIFF
--- a/__tests__/components/__snapshots__/OrgSelector.test.jsx.snap
+++ b/__tests__/components/__snapshots__/OrgSelector.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`<OrgSelector /> matches snapshot 1`] = `
     fullWidth={false}
     multiple={false}
     onChange={[Function]}
-    value={0}>
+    value={null}>
     <MenuItem
       anchorOrigin={
         Object {

--- a/__tests__/components/__snapshots__/SaveMenu.test.jsx.snap
+++ b/__tests__/components/__snapshots__/SaveMenu.test.jsx.snap
@@ -126,7 +126,8 @@ exports[`<SaveMenu /> snapshot tests matches default snapshot 1`] = `
         Array [
           "galactic-federation",
         ]
-      } />
+      }
+      value="" />
   </Dialog>
 </span>
 `;
@@ -259,7 +260,8 @@ exports[`<SaveMenu /> snapshot tests matches snapshot when saving is not enabled
         Array [
           "galactic-federation",
         ]
-      } />
+      }
+      value="" />
   </Dialog>
 </span>
 `;
@@ -392,7 +394,8 @@ exports[`<SaveMenu /> snapshot tests matches snapshot when user cannot save 1`] 
         Array [
           "galactic-federation",
         ]
-      } />
+      }
+      value="" />
   </Dialog>
 </span>
 `;

--- a/src/components/OrgSelector.jsx
+++ b/src/components/OrgSelector.jsx
@@ -1,7 +1,9 @@
-import React, { PropTypes } from 'react'
-import { SelectField, MenuItem } from 'material-ui'
+import React, { PropTypes } from 'react';
+import { SelectField, MenuItem } from 'material-ui';
 
-const isEmpty = (arr) => arr.length === 0
+import CustomPropTypes from '../util/custom-prop-types';
+
+const isEmpty = arr => arr.length === 0;
 
 class OrgSelector extends React.Component {
   constructor(props) {
@@ -9,35 +11,38 @@ class OrgSelector extends React.Component {
     this.handleChange = this.handleChange.bind(this);
   }
   handleChange(ev, tgt, value) {
-    const { onChange } = this.props
-    onChange(value)
+    const { onChange } = this.props;
+    onChange(value);
   }
   render() {
     const { value, orgs, style } = this.props;
+    let menuItems;
+    if (isEmpty(orgs)) {
+      menuItems = (
+        <MenuItem
+          value={null}
+          primaryText="Role"
+        />
+      );
+    } else {
+      menuItems = orgs.map(org => (
+        <MenuItem
+          key={org}
+          value={org}
+          primaryText={org}
+        />
+      ));
+    }
     return (
       <div>
         <SelectField
-          value={value || 0}
+          disabled={!value}
+          floatingLabelText="Role"
           onChange={this.handleChange}
           style={style}
-          disabled={!value}
-          floatingLabelText='Role'
-          >
-          {isEmpty(orgs) //No option to set default, so I'll populate with one
-                         //instead
-            ?
-            <MenuItem
-              value={0}
-              primaryText={"Role"}
-            />
-            :
-            orgs.map((org) => (
-            <MenuItem
-              key={org}
-              value={org}
-              primaryText={org}
-            />
-          ))}
+          value={value || null}
+        >
+          {menuItems}
         </SelectField>
       </div>
     );
@@ -45,10 +50,13 @@ class OrgSelector extends React.Component {
 }
 
 OrgSelector.propTypes = {
-  orgs: PropTypes.arrayOf(PropTypes.string).isRequired,
-  value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
-  style: PropTypes.object
-}
+  orgs: CustomPropTypes.orgs.isRequired,
+  value: PropTypes.string,
+};
+
+OrgSelector.defaultProps = {
+  value: '',
+};
 
 export default OrgSelector;

--- a/src/components/SnippetAreaToolbar.jsx
+++ b/src/components/SnippetAreaToolbar.jsx
@@ -6,6 +6,7 @@ import {
 import LanguageSelector from './LanguageSelector';
 import LockButton from './buttons/LockButton';
 import SaveMenu from './menus/SaveMenu';
+import CustomPropTypes from '../util/custom-prop-types';
 
 const styles = {
   toolbar: {
@@ -52,7 +53,7 @@ const SnippetAreaToolbar = (props) => {
     saveEnabled,
     title,
     orgs,
-    selectedOrg
+    selectedOrg,
   } = props;
 
   return (
@@ -104,8 +105,12 @@ SnippetAreaToolbar.propTypes = {
   readOnly: PropTypes.bool.isRequired,
   saveEnabled: PropTypes.bool.isRequired,
   title: PropTypes.string.isRequired,
-  orgs: PropTypes.array.isRequired,
-  selectedOrg: PropTypes.string
+  orgs: CustomPropTypes.orgs.isRequired,
+  selectedOrg: PropTypes.string,
+};
+
+SnippetAreaToolbar.defaultProps = {
+  selectedOrg: '',
 };
 
 export default SnippetAreaToolbar;

--- a/src/components/menus/SaveMenu.jsx
+++ b/src/components/menus/SaveMenu.jsx
@@ -10,6 +10,7 @@ import {
 import SaveIcon from 'material-ui/svg-icons/content/save';
 
 import OrgSelector from '../OrgSelector';
+import CustomPropTypes from '../../util/custom-prop-types';
 
 const styles = {
   container: {
@@ -62,7 +63,11 @@ class SaveMenu extends React.Component {
   }
 
   getSaveAsDialog() {
-    const { orgs, selectedOrg, onOrgChanged } = this.props;
+    const {
+      onOrgChanged,
+      orgs,
+      selectedOrg,
+    } = this.props;
     return (
       <Dialog
         actions={
@@ -111,8 +116,15 @@ class SaveMenu extends React.Component {
 SaveMenu.propTypes = {
   canSave: PropTypes.bool.isRequired,
   enabled: PropTypes.bool.isRequired,
+  onOrgChanged: PropTypes.func.isRequired,
   onSaveAsClick: PropTypes.func.isRequired,
   onSaveClick: PropTypes.func.isRequired,
+  orgs: CustomPropTypes.orgs.isRequired,
+  selectedOrg: PropTypes.string,
+};
+
+SaveMenu.defaultProps = {
+  selectedOrg: '',
 };
 
 export default SaveMenu;

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -121,7 +121,6 @@ export class SnippetArea extends React.Component {
   }
 
   handleSave() {
-
     const {
       dispatch,
       router,
@@ -186,7 +185,7 @@ export class SnippetArea extends React.Component {
     const {
       dispatch,
       router,
-      selectedOrg
+      selectedOrg,
     } = this.props;
     // Render the new title
     dispatch(setSnippetTitle(title));
@@ -232,7 +231,7 @@ export class SnippetArea extends React.Component {
       snippetLanguage,
       snippetTitle,
       orgs,
-      selectedOrg
+      selectedOrg,
     } = this.props;
 
     const markedLines = Object.keys(annotations).map(key => Number(key));
@@ -289,26 +288,49 @@ SnippetArea.propTypes = {
   snippetTitle: PropTypes.string.isRequired,
   permissions: CustomPropTypes.permissions.isRequired,
   snippetLanguage: PropTypes.string.isRequired,
+  orgs: CustomPropTypes.orgs.isRequired,
+  selectedOrg: PropTypes.string,
 };
 
 SnippetArea.defaultProps = {
   openLine: -1,
+  selectedOrg: '',
 };
 
-const mapStateToProps = state => ({
-  annotations: state.app.annotations,
-  AST: state.app.AST,
-  filters: state.app.filters,
-  snippetLanguage: state.app.snippetLanguage,
-  openLine: (state.annotation.isDisplayingAnnotation
-    ? state.annotation.lineAnnotated.lineNumber : undefined),
-  readOnly: state.app.readOnly,
-  snippet: state.app.snippet,
-  snippetTitle: state.app.snippetTitle,
-  appState: state.app,
-  permissions: state.permissions,
-  orgs: state.user.orgs,
-  selectedOrg: state.user.selectedOrg,
-});
+const mapStateToProps = (state) => {
+  const {
+    annotation: {
+      isDisplayingAnnotation,
+      lineAnnotated,
+    },
+    app: {
+      annotations,
+      AST,
+      filters,
+      snippetLanguage,
+      readOnly,
+      snippet,
+      snippetTitle,
+    },
+    permissions,
+    user: {
+      orgs,
+      selectedOrg,
+    },
+  } = state;
+  return {
+    annotations,
+    AST,
+    filters,
+    snippetLanguage,
+    openLine: (isDisplayingAnnotation ? lineAnnotated.lineNumber : undefined),
+    readOnly,
+    snippet,
+    snippetTitle,
+    permissions,
+    orgs,
+    selectedOrg,
+  };
+};
 
 export default withRouter(connect(mapStateToProps)(SnippetArea));

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -6,66 +6,64 @@ export const initialState = {
   token: '',
   username: '',
   userSnippets: {},
-}
+};
 
-const user = (state=initialState, action) => {
+const user = (state = initialState, action) => {
   switch (action.type) {
-    case actions.ADD_ORG: {
-      const org = action.payload;
-      if(state.orgs.indexOf(org) >= 0) {
-        return state;
-      } else {
-        return {
-          ...state,
-          orgs: state.orgs.slice().concat(org)
-        };
-      }
-    }
-    case actions.SWITCH_ORG: {
-      const org = action.payload;
-      if (state.orgs.indexOf(org) >= 0) {
-        return {
-          ...state,
-          selectedOrg: org
-        };
-      } else {
-        return state;
-      }
-    }
-    case actions.SET_USER_SNIPPETS: {
-      return {
-        ...state,
-        userSnippets: action.payload,
-      }
-    }
-    case actions.RESTORE_USER_CREDENTIALS: {
-      return {
-        ...state,
-        ...action.payload,
-      }
-    }
-    case actions.SAVE_USERNAME: {
-      return {
-        ...state,
-        username: action.payload,
-      };
-    }
-    case actions.SAVE_ACCESS_TOKEN: {
-      return {
-        ...state,
-        token: action.payload,
-      };
-    }
-    case actions.CLEAR_USER_CREDENTIALS: {
-      return {
-        ...initialState,
-        orgs: state.orgs,
-        selectedOrg: state.selectedOrg
-      };
-    }
-    default: {
+  case actions.ADD_ORG: {
+    const org = action.payload;
+    if (state.orgs.indexOf(org) >= 0) {
       return state;
     }
+    return {
+      ...state,
+      orgs: state.orgs.slice().concat(org),
+    };
+  }
+  case actions.SWITCH_ORG: {
+    const org = action.payload;
+    if (state.orgs.indexOf(org) !== -1) {
+      return {
+        ...state,
+        selectedOrg: org,
+      };
+    }
+    return state;
+  }
+  case actions.SET_USER_SNIPPETS: {
+    return {
+      ...state,
+      userSnippets: action.payload,
+    };
+  }
+  case actions.RESTORE_USER_CREDENTIALS: {
+    return {
+      ...state,
+      ...action.payload,
+    };
+  }
+  case actions.SAVE_USERNAME: {
+    return {
+      ...state,
+      username: action.payload,
+    };
+  }
+  case actions.SAVE_ACCESS_TOKEN: {
+    return {
+      ...state,
+      token: action.payload,
+    };
+  }
+  case actions.CLEAR_USER_CREDENTIALS: {
+    return {
+      ...initialState,
+      orgs: state.orgs,
+      selectedOrg: state.selectedOrg,
+    };
+  }
+  default: {
+    return state;
+  }
   }
 };
 

--- a/src/util/custom-prop-types.js
+++ b/src/util/custom-prop-types.js
@@ -33,10 +33,13 @@ const snippetData = PropTypes.shape({
 
 const snippets = PropTypes.objectOf(snippetData);
 
+const orgs = PropTypes.arrayOf(PropTypes.string);
+
 export default {
   annotations,
   filters,
   lineAnnotated,
+  orgs,
   permissions,
   snippets,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a custom prop type for `orgs` and refactors `mapStateToProps` and propTypes in `SnippetArea`

## Motivation and Context
Does not fix a card, but I dislike starting a new feature and having eslint yell at me for that code.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
