### PR TITLE
Annotation appearance changes

### DIFF
--- a/__tests__/components/AnnotationDisplay.test.jsx
+++ b/__tests__/components/AnnotationDisplay.test.jsx
@@ -63,7 +63,7 @@ describe('<AnnotationDisplay />', () => {
   });
 
   describe('prop: annotation', () => {
-    it('is rendered into a MarkdownRenderer', () => {
+    it('is forwarded to MarkdownDisplayer', () => {
       const annotation = 'Wubba lubba dub dub!';
       const wrapper = shallowWithContext(
         <AnnotationDisplay
@@ -71,7 +71,7 @@ describe('<AnnotationDisplay />', () => {
           annotation={annotation}
         />,
       );
-      expect(wrapper.find('MarkdownRenderer').prop('markdown')).toEqual(annotation);
+      expect(wrapper.find('MarkdownDisplayer').prop('annotation')).toEqual(annotation);
     });
   });
 });

--- a/__tests__/components/MarkdownDisplayer.test.jsx
+++ b/__tests__/components/MarkdownDisplayer.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+import MarkdownDisplayer from '../../src/components/MarkdownDisplayer';
+
+const defaultProps = {
+  annotation: '',
+};
+
+describe('<MarkdownDisplayer />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = node => shallow(node, { context: { muiTheme } });
+
+  describe('snapshots', () => {
+    describe('matches snapshot', () => {
+      it('matches snapshot', () => {
+        const wrapper =
+          shallowWithContext(<MarkdownDisplayer {...defaultProps} />);
+        expect(shallowToJson(wrapper)).toMatchSnapshot();
+      });
+    });
+    describe('prop: annotation', () => {
+      it('is forwarded to MarkdownRenderer', () => {
+        const annotation = 'No jumping in the sewer!';
+        const wrapper = shallowWithContext(
+          <MarkdownDisplayer annotation={annotation} />,
+        );
+        const markdownRenderer = wrapper.find('MarkdownRenderer');
+        expect(markdownRenderer.prop('markdown')).toEqual(annotation);
+      });
+    });
+  });
+});

--- a/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
@@ -19,7 +19,12 @@ exports[`<AnnotationDisplay /> snapshots when an annotation after current one ex
         labelPosition="after"
         onTouchTap={[Function]}
         primary={false}
-        secondary={true} />
+        secondary={true}
+        style={
+          Object {
+            "marginRight": "0.2rem",
+          }
+        } />
       <RaisedButton
         disabled={false}
         fullWidth={false}
@@ -85,7 +90,12 @@ exports[`<AnnotationDisplay /> snapshots when an annotation before current one e
         labelPosition="after"
         onTouchTap={[Function]}
         primary={false}
-        secondary={true} />
+        secondary={true}
+        style={
+          Object {
+            "marginRight": "0.2rem",
+          }
+        } />
       <RaisedButton
         disabled={false}
         fullWidth={false}
@@ -151,7 +161,12 @@ exports[`<AnnotationDisplay /> snapshots when annotation exists before/after cur
         labelPosition="after"
         onTouchTap={[Function]}
         primary={false}
-        secondary={true} />
+        secondary={true}
+        style={
+          Object {
+            "marginRight": "0.2rem",
+          }
+        } />
       <RaisedButton
         disabled={false}
         fullWidth={false}
@@ -217,7 +232,12 @@ exports[`<AnnotationDisplay /> snapshots when no annotations before/after curren
         labelPosition="after"
         onTouchTap={[Function]}
         primary={false}
-        secondary={true} />
+        secondary={true}
+        style={
+          Object {
+            "marginRight": "0.2rem",
+          }
+        } />
       <RaisedButton
         disabled={false}
         fullWidth={false}

--- a/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
@@ -1,13 +1,7 @@
 exports[`<AnnotationDisplay /> snapshots when an annotation after current one exists matches snapshot 1`] = `
 <div>
-  <MarkdownRenderer
-    markdown=""
-    options={
-      Object {
-        "highlight": [Function],
-        "langPrefix": "hljs language-",
-      }
-    } />
+  <MarkdownDisplayer
+    annotation="" />
   <div
     style={
       Object {
@@ -72,14 +66,8 @@ exports[`<AnnotationDisplay /> snapshots when an annotation after current one ex
 
 exports[`<AnnotationDisplay /> snapshots when an annotation before current one exists matches snapshot 1`] = `
 <div>
-  <MarkdownRenderer
-    markdown=""
-    options={
-      Object {
-        "highlight": [Function],
-        "langPrefix": "hljs language-",
-      }
-    } />
+  <MarkdownDisplayer
+    annotation="" />
   <div
     style={
       Object {
@@ -144,14 +132,8 @@ exports[`<AnnotationDisplay /> snapshots when an annotation before current one e
 
 exports[`<AnnotationDisplay /> snapshots when annotation exists before/after current one matches snapshot 1`] = `
 <div>
-  <MarkdownRenderer
-    markdown=""
-    options={
-      Object {
-        "highlight": [Function],
-        "langPrefix": "hljs language-",
-      }
-    } />
+  <MarkdownDisplayer
+    annotation="" />
   <div
     style={
       Object {
@@ -216,14 +198,8 @@ exports[`<AnnotationDisplay /> snapshots when annotation exists before/after cur
 
 exports[`<AnnotationDisplay /> snapshots when no annotations before/after current one exist matches snapshot 1`] = `
 <div>
-  <MarkdownRenderer
-    markdown=""
-    options={
-      Object {
-        "highlight": [Function],
-        "langPrefix": "hljs language-",
-      }
-    } />
+  <MarkdownDisplayer
+    annotation="" />
   <div
     style={
       Object {

--- a/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
@@ -27,14 +27,8 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
     </Tab>
     <Tab
       label="Preview">
-      <MarkdownRenderer
-        markdown=""
-        options={
-          Object {
-            "highlight": [Function],
-            "langPrefix": "hljs language-",
-          }
-        } />
+      <MarkdownDisplayer
+        annotation="" />
     </Tab>
   </Tabs>
   <div
@@ -43,6 +37,7 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
         "alignItems": "center",
         "display": "flex",
         "flexFlow": "row wrap",
+        "marginTop": "0.5rem",
       }
     }>
     <RaisedButton

--- a/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
@@ -10,7 +10,6 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
         autoFocus={true}
         disabled={false}
         floatingLabelFixed={false}
-        floatingLabelText="Annotation"
         fullWidth={true}
         hintText="Enter your annotation here"
         multiLine={true}

--- a/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
@@ -40,6 +40,7 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
   <div
     style={
       Object {
+        "alignItems": "center",
         "display": "flex",
         "flexFlow": "row wrap",
       }

--- a/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
@@ -11,6 +11,11 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
         disabled={false}
         floatingLabelFixed={false}
         fullWidth={true}
+        hintStyle={
+          Object {
+            "top": "1rem",
+          }
+        }
         hintText="Enter your annotation here"
         multiLine={true}
         name="annotationEditor"

--- a/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
@@ -53,6 +53,7 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
           "flexBasis": "auto",
           "flexFlow": 1,
           "flexShrink": 1,
+          "marginRight": "0.2rem",
         }
       } />
     <RaisedButton

--- a/__tests__/components/__snapshots__/LineSnippet.test.jsx.snap
+++ b/__tests__/components/__snapshots__/LineSnippet.test.jsx.snap
@@ -1,15 +1,24 @@
 exports[`<LanguageSelector /> matches snapshot 1`] = `
-<CodeMirror
-  options={
-    Object {
-      "cursorBlinkRate": -1,
-      "firstLineNumber": 1,
-      "lineNumbers": true,
-      "lineWrapping": true,
-      "readOnly": true,
-      "theme": "codesplain",
-    }
-  }
-  preserveScrollPosition={false}
-  value="foo bar baz" />
+<div>
+  <Paper
+    circle={false}
+    rounded={true}
+    transitionEnabled={true}
+    zDepth={1}>
+    <CodeMirror
+      options={
+        Object {
+          "cursorBlinkRate": -1,
+          "firstLineNumber": 1,
+          "lineNumbers": true,
+          "lineWrapping": true,
+          "readOnly": true,
+          "theme": "codesplain",
+        }
+      }
+      preserveScrollPosition={false}
+      value="foo bar baz" />
+  </Paper>
+  <br />
+</div>
 `;

--- a/__tests__/components/__snapshots__/MarkdownDisplayer.test.jsx.snap
+++ b/__tests__/components/__snapshots__/MarkdownDisplayer.test.jsx.snap
@@ -1,0 +1,20 @@
+exports[`<MarkdownDisplayer /> snapshots matches snapshot matches snapshot 1`] = `
+<Card
+  expandable={false}
+  expanded={null}
+  initiallyExpanded={false}
+  style={
+    Object {
+      "padding": "0.5rem",
+    }
+  }>
+  <MarkdownRenderer
+    markdown=""
+    options={
+      Object {
+        "highlight": [Function],
+        "langPrefix": "hljs language-",
+      }
+    } />
+</Card>
+`;

--- a/src/components/AnnotationDisplay.jsx
+++ b/src/components/AnnotationDisplay.jsx
@@ -18,6 +18,9 @@ const styles = {
     flex: '0 1 auto',
     justifyContent: 'flex-end',
   },
+  cancelButton: {
+    marginRight: '0.2rem',
+  },
 };
 
 const AnnotationDisplay = (props) => {
@@ -35,11 +38,12 @@ const AnnotationDisplay = (props) => {
     <div>
       <MarkdownDisplayer annotation={annotation} />
       <div style={styles.actionRow}>
-        <div>
+        <div style={styles.actionButtons}>
           <RaisedButton
             label="Close"
             onTouchTap={closeAnnotation}
             secondary
+            style={styles.cancelButton}
           />
           <RaisedButton
             label="Edit"

--- a/src/components/AnnotationDisplay.jsx
+++ b/src/components/AnnotationDisplay.jsx
@@ -1,11 +1,10 @@
 import React, { PropTypes } from 'react';
-import MarkdownRenderer from 'react-markdown-renderer';
 import RaisedButton from 'material-ui/RaisedButton';
 import IconButton from 'material-ui/IconButton';
 import Previous from 'material-ui/svg-icons/navigation/arrow-back';
 import Next from 'material-ui/svg-icons/navigation/arrow-forward';
 
-import markdownRendererOptions from '../util/markdown-renderer-options';
+import MarkdownDisplayer from './MarkdownDisplayer';
 
 const styles = {
   actionRow: {
@@ -34,10 +33,7 @@ const AnnotationDisplay = (props) => {
 
   return (
     <div>
-      <MarkdownRenderer
-        markdown={annotation}
-        options={markdownRendererOptions}
-      />
+      <MarkdownDisplayer annotation={annotation} />
       <div style={styles.actionRow}>
         <div>
           <RaisedButton

--- a/src/components/AnnotationEditor.jsx
+++ b/src/components/AnnotationEditor.jsx
@@ -11,6 +11,7 @@ const styles = {
   bottomContainer: {
     display: 'flex',
     flexFlow: 'row wrap',
+    alignItems: 'center',
   },
   button: {
     flexFlow: 1,

--- a/src/components/AnnotationEditor.jsx
+++ b/src/components/AnnotationEditor.jsx
@@ -1,10 +1,9 @@
 import React, { PropTypes } from 'react';
-import MarkdownRenderer from 'react-markdown-renderer';
 import { Tab, Tabs } from 'material-ui/Tabs';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 
-import markdownRendererOptions from '../util/markdown-renderer-options';
+import MarkdownDisplayer from './MarkdownDisplayer';
 import markdownLogo from '../../res/markdown-logo.svg';
 
 const styles = {
@@ -12,6 +11,7 @@ const styles = {
     display: 'flex',
     flexFlow: 'row wrap',
     alignItems: 'center',
+    marginTop: '0.5rem',
   },
   button: {
     flexFlow: 1,
@@ -64,6 +64,7 @@ class AnnotationEditor extends React.Component {
   }
 
   render() {
+    const { annotation } = this.state;
     return (
       <div>
         <Tabs>
@@ -81,14 +82,11 @@ class AnnotationEditor extends React.Component {
               onChange={this.onAnnotationChange}
               ref={(textField) => { this.textField = textField; }}
               rows={4}
-              value={this.state.annotation}
+              value={annotation}
             />
           </Tab>
           <Tab label="Preview">
-            <MarkdownRenderer
-              markdown={this.state.annotation}
-              options={markdownRendererOptions}
-            />
+            <MarkdownDisplayer annotation={annotation} />
           </Tab>
         </Tabs>
         <div style={styles.bottomContainer}>
@@ -99,7 +97,7 @@ class AnnotationEditor extends React.Component {
             style={styles.button}
           />
           <RaisedButton
-            disabled={!this.state.annotation}
+            disabled={!annotation}
             label="Save"
             onTouchTap={this.saveAnnotation}
             primary

--- a/src/components/AnnotationEditor.jsx
+++ b/src/components/AnnotationEditor.jsx
@@ -17,6 +17,9 @@ const styles = {
     flexShrink: 1,
     flexBasis: 'auto',
   },
+  hintText: {
+    top: '1rem',
+  },
   markdownHintText: {
     color: '#d3d3d3',
   },
@@ -70,6 +73,7 @@ class AnnotationEditor extends React.Component {
             <TextField
               autoFocus
               fullWidth
+              hintStyle={styles.hintText}
               hintText="Enter your annotation here"
               multiLine
               name="annotationEditor"

--- a/src/components/AnnotationEditor.jsx
+++ b/src/components/AnnotationEditor.jsx
@@ -18,6 +18,12 @@ const styles = {
     flexShrink: 1,
     flexBasis: 'auto',
   },
+  cancelButton: {
+    flexFlow: 1,
+    flexShrink: 1,
+    flexBasis: 'auto',
+    marginRight: '0.2rem',
+  },
   hintText: {
     top: '1rem',
   },
@@ -94,7 +100,7 @@ class AnnotationEditor extends React.Component {
             label="Cancel"
             onTouchTap={this.clearAnnotation}
             secondary
-            style={styles.button}
+            style={styles.cancelButton}
           />
           <RaisedButton
             disabled={!annotation}

--- a/src/components/AnnotationEditor.jsx
+++ b/src/components/AnnotationEditor.jsx
@@ -69,7 +69,6 @@ class AnnotationEditor extends React.Component {
           >
             <TextField
               autoFocus
-              floatingLabelText="Annotation"
               fullWidth
               hintText="Enter your annotation here"
               multiLine
@@ -103,9 +102,9 @@ class AnnotationEditor extends React.Component {
           />
           <a
             href="http://commonmark.org/help"
+            rel="noopener noreferrer"
             style={styles.markdownIndicator}
             target="_blank"
-            rel="noopener noreferrer"
           >
             <img
               alt="Markdown Logo"

--- a/src/components/LineSnippet.jsx
+++ b/src/components/LineSnippet.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import CodeMirror from 'react-codemirror';
+import Paper from 'material-ui/Paper';
 
 // Base options for CodeMirror instances for a LineSnippet
 const baseOptions = {
@@ -25,11 +26,16 @@ class LineSnippet extends React.Component {
       firstLineNumber: lineNumber,
     };
     return (
-      <CodeMirror
-        ref={(cm) => { this.codeMirror = cm; }}
-        value={value}
-        options={codeMirrorOptions}
-      />
+      <div>
+        <Paper>
+          <CodeMirror
+            ref={(cm) => { this.codeMirror = cm; }}
+            value={value}
+            options={codeMirrorOptions}
+          />
+        </Paper>
+        <br />
+      </div>
     );
   }
 }

--- a/src/components/MarkdownDisplayer.jsx
+++ b/src/components/MarkdownDisplayer.jsx
@@ -1,0 +1,26 @@
+import React, { PropTypes } from 'react';
+import MarkdownRenderer from 'react-markdown-renderer';
+import { Card } from 'material-ui';
+
+import markdownRendererOptions from '../util/markdown-renderer-options';
+
+const styles = {
+  card: {
+    padding: '0.5rem',
+  },
+};
+
+const MarkdownDisplayer = ({ annotation }) => (
+  <Card style={styles.card} >
+    <MarkdownRenderer
+      markdown={annotation}
+      options={markdownRendererOptions}
+    />
+  </Card>
+);
+
+MarkdownDisplayer.propTypes = {
+  annotation: PropTypes.string.isRequired,
+};
+
+export default MarkdownDisplayer;


### PR DESCRIPTION
## Description
This PR enhances the appearance of the Annotation section. It separates the various child components within the section (like the line annotated and the annotation itself) by embedding them inside `Card` components, and applies more spacing in between the components

## Motivation and Context
Fixes #394 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
<img width="656" alt="screen shot 2017-04-27 at 11 04 32 am" src="https://cloud.githubusercontent.com/assets/10211603/25492672/67bea208-2b39-11e7-80f7-5571ab1d7e4d.png">

<img width="654" alt="screen shot 2017-04-27 at 11 04 51 am" src="https://cloud.githubusercontent.com/assets/10211603/25492684/6e729f32-2b39-11e7-899e-b36ae27d7e3b.png">

<img width="659" alt="screen shot 2017-04-27 at 11 04 56 am" src="https://cloud.githubusercontent.com/assets/10211603/25492690/7432ee18-2b39-11e7-9d67-1c7605767470.png">

<img width="658" alt="screen shot 2017-04-27 at 11 05 01 am" src="https://cloud.githubusercontent.com/assets/10211603/25492691/7451630c-2b39-11e7-8952-ab07408e6306.png">


