### PR TITLE
Visual error143

### DIFF
--- a/__tests__/actions/parser.js
+++ b/__tests__/actions/parser.js
@@ -11,8 +11,8 @@ describe('Actions: parser', () => {
       expect(actions.loadParser(language)).toEqual(expect.objectContaining(expected));
     });
   });
-  describe('SET_ERROR', () => {
-    it('creates an action to set an error', () => {
+  describe('ADD_ERROR', () => {
+    it('creates an action to add an error', () => {
       const error = {
         type: 'syntaxError',
         begin: 5,
@@ -20,17 +20,17 @@ describe('Actions: parser', () => {
         msg: 'blahblahblah',
       };
       const expected = {
-        type: actions.SET_ERROR,
+        type: actions.ADD_ERROR,
         payload: error,
       };
-      expect(actions.setError(error)).toEqual(expected);
+      expect(actions.addError(error)).toEqual(expected);
     });
-    describe('SET_NO_ERROR', () => {
-      it('creates an action to remove errors from state', () => {
+    describe('CLEAR_ERRORS', () => {
+      it('creates an action to remove all errors from state', () => {
         const expected = {
-          type: actions.SET_NO_ERROR,
+          type: actions.CLEAR_ERRORS,
         };
-        expect(actions.setNoError()).toEqual(expected);
+        expect(actions.clearErrors()).toEqual(expected);
       });
     });
   });

--- a/__tests__/actions/parser.js
+++ b/__tests__/actions/parser.js
@@ -11,4 +11,27 @@ describe('Actions: parser', () => {
       expect(actions.loadParser(language)).toEqual(expect.objectContaining(expected));
     });
   });
+  describe('SET_ERROR', () => {
+    it('creates an action to set an error', () => {
+      const error = {
+        type: 'syntaxError',
+        begin: 5,
+        end: NaN,
+        msg: 'blahblahblah',
+      };
+      const expected = {
+        type: actions.SET_ERROR,
+        payload: error,
+      };
+      expect(actions.setError(error)).toEqual(expected);
+    });
+    describe('SET_NO_ERROR', () => {
+      it('creates an action to remove errors from state', () => {
+        const expected = {
+          type: actions.SET_NO_ERROR,
+        };
+        expect(actions.setNoError()).toEqual(expected);
+      });
+    });
+  });
 });

--- a/__tests__/reducers/__snapshots__/parser.js.snap
+++ b/__tests__/reducers/__snapshots__/parser.js.snap
@@ -1,5 +1,6 @@
 exports[`Reducer: Parser should have initial state 1`] = `
 Object {
+  "error": null,
   "language": "",
 }
 `;

--- a/__tests__/reducers/__snapshots__/parser.js.snap
+++ b/__tests__/reducers/__snapshots__/parser.js.snap
@@ -1,6 +1,6 @@
 exports[`Reducer: Parser should have initial state 1`] = `
 Object {
-  "error": null,
+  "errors": Array [],
   "language": "",
 }
 `;

--- a/__tests__/reducers/parser.js
+++ b/__tests__/reducers/parser.js
@@ -18,7 +18,7 @@ describe('Reducer: Parser', () => {
     expect(reducer(undefined, action)).toEqual(expect.objectContaining(expected));
   });
 
-  it('should handle SET_ERROR', () => {
+  it('should handle ADD_ERROR', () => {
     const error = {
       type: 'syntaxError',
       begin: 5,
@@ -26,20 +26,20 @@ describe('Reducer: Parser', () => {
       msg: 'blahblahblah',
     };
     const action = {
-      type: actions.SET_ERROR,
+      type: actions.ADD_ERROR,
       payload: error,
     };
-    const expected = { error };
+    const expected = { errors: [error] };
     expect(reducer(undefined, action)).toEqual(expect.objectContaining(expected));
   });
 
-  it('should handle SET_NO_ERROR', () => {
+  it('should handle CLEAR_ERRORS', () => {
     const error = null;
     const action = {
-      type: actions.SET_ERROR,
+      type: actions.CLEAR_ERRORS,
       payload: error,
     };
-    const expected = { error };
+    const expected = { errors: [] };
     expect(reducer(undefined, action)).toEqual(expect.objectContaining(expected));
   });
 });

--- a/__tests__/reducers/parser.js
+++ b/__tests__/reducers/parser.js
@@ -17,4 +17,29 @@ describe('Reducer: Parser', () => {
     };
     expect(reducer(undefined, action)).toEqual(expect.objectContaining(expected));
   });
+
+  it('should handle SET_ERROR', () => {
+    const error = {
+      type: 'syntaxError',
+      begin: 5,
+      end: NaN,
+      msg: 'blahblahblah',
+    };
+    const action = {
+      type: actions.SET_ERROR,
+      payload: error,
+    };
+    const expected = { error };
+    expect(reducer(undefined, action)).toEqual(expect.objectContaining(expected));
+  });
+
+  it('should handle SET_NO_ERROR', () => {
+    const error = null;
+    const action = {
+      type: actions.SET_ERROR,
+      payload: error,
+    };
+    const expected = { error };
+    expect(reducer(undefined, action)).toEqual(expect.objectContaining(expected));
+  });
 });

--- a/src/actions/parser.js
+++ b/src/actions/parser.js
@@ -1,6 +1,6 @@
 export const LOAD_PARSER = 'LOAD_PARSER';
-export const SET_ERROR = 'SET_ERROR';
-export const SET_NO_ERROR = 'SET_NO_ERROR';
+export const ADD_ERROR = 'ADD_ERROR';
+export const CLEAR_ERRORS = 'CLEAR_ERRORS';
 
 export const loadParser = language => ({
   type: LOAD_PARSER,
@@ -10,11 +10,11 @@ export const loadParser = language => ({
   payload: language,
 });
 
-export const setError = error => ({
-  type: SET_ERROR,
+export const addError = error => ({
+  type: ADD_ERROR,
   payload: error,
 });
 
-export const setNoError = () => ({
-  type: SET_NO_ERROR,
+export const clearErrors = () => ({
+  type: CLEAR_ERRORS,
 });

--- a/src/actions/parser.js
+++ b/src/actions/parser.js
@@ -1,4 +1,6 @@
 export const LOAD_PARSER = 'LOAD_PARSER';
+export const SET_ERROR = 'SET_ERROR';
+export const SET_NO_ERROR = 'SET_NO_ERROR';
 
 export const loadParser = language => ({
   type: LOAD_PARSER,
@@ -6,4 +8,13 @@ export const loadParser = language => ({
     WebWorker: true,
   },
   payload: language,
+});
+
+export const setError = error => ({
+  type: SET_ERROR,
+  payload: error,
+});
+
+export const setNoError = () => ({
+  type: SET_NO_ERROR,
 });

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -109,9 +109,7 @@ class Editor extends React.Component {
     }
     if (errors) {
       errors.forEach((error) => {
-        let end = error.end ? error.end : value.length;
-        if (end < error.begin) end = error.begin;
-        this.markError(error.begin, end);
+        this.markError(error.begin, error.end);
       });
     }
   }

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -82,7 +82,7 @@ class Editor extends React.Component {
       AST,
       filters,
       value,
-      error,
+      errors,
     } = this.props;
     const {
       newAST,
@@ -107,10 +107,12 @@ class Editor extends React.Component {
     if ((newAST || newFilters) && value) {
       highlight(codeMirrorInst, AST, filters);
     }
-    if (error) {
-      let end = error.end ? error.end : value.length;
-      if (end > error.begin) end = error.begin;
-      this.markError(error.begin, error.end ? error.end : value.length);
+    if (errors) {
+      errors.forEach((error) => {
+        let end = error.end ? error.end : value.length;
+        if (end < error.begin) end = error.begin;
+        this.markError(error.begin, end);
+      });
     }
   }
 
@@ -142,7 +144,6 @@ class Editor extends React.Component {
   }
 
   markError(startIdx, stopIdx) {
-    console.log(`marking error from ${startIdx} to ${stopIdx}`)
     // http://stackoverflow.com/questions/39432258/how-to-create-a-wavy-underline-on-mutilline-text-with-css
     const css = `
       background-image:
@@ -158,7 +159,6 @@ class Editor extends React.Component {
   }
 
   clearErrors() {
-    console.log('clearing errors');
     const css = `
       background-image: none;
     `;
@@ -198,11 +198,12 @@ Editor.propTypes = {
   openLine: PropTypes.number,
   readOnly: PropTypes.bool.isRequired,
   value: PropTypes.string.isRequired,
-  error: CustomPropTypes.error.isRequired,
+  errors: CustomPropTypes.errors,
 };
 
 Editor.defaultProps = {
   openLine: -1,
+  errors: [],
 };
 
 export default Editor;

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -9,6 +9,7 @@ import {
   highlight,
   styleLine,
   styleAll,
+  styleRegion,
 } from '../util/codemirror-utils';
 import CustomPropTypes from '../util/custom-prop-types';
 import '../styles/codesplain.css';
@@ -55,6 +56,8 @@ class Editor extends React.Component {
     this.handleGutterClick = this.handleGutterClick.bind(this);
     this.emphasizeLine = this.emphasizeLine.bind(this);
     this.deEmphasize = this.deEmphasize.bind(this);
+    this.markError = this.markError.bind(this);
+    this.clearErrors = this.clearErrors.bind(this);
   }
 
   componentDidMount() {
@@ -79,6 +82,7 @@ class Editor extends React.Component {
       AST,
       filters,
       value,
+      error,
     } = this.props;
     const {
       newAST,
@@ -96,11 +100,17 @@ class Editor extends React.Component {
       codeMirrorInst.setGutterMarker(Number(lineNumber), 'annotations', makeMarker());
     });
     this.deEmphasize();
+    this.clearErrors();
     if (openLine !== -1) {
       this.emphasizeLine(openLine);
     }
     if ((newAST || newFilters) && value) {
       highlight(codeMirrorInst, AST, filters);
+    }
+    if (error) {
+      let end = error.end ? error.end : value.length;
+      if (end > error.begin) end = error.begin;
+      this.markError(error.begin, error.end ? error.end : value.length);
     }
   }
 
@@ -128,6 +138,30 @@ class Editor extends React.Component {
   // If a line has been previously emphasized, this will de-emphasise it.
   deEmphasize() {
     const css = 'font-weight: normal; opacity: 1.0;';
+    styleAll(this.codeMirror.getCodeMirror(), css);
+  }
+
+  markError(startIdx, stopIdx) {
+    console.log(`marking error from ${startIdx} to ${stopIdx}`)
+    // http://stackoverflow.com/questions/39432258/how-to-create-a-wavy-underline-on-mutilline-text-with-css
+    const css = `
+      background-image:
+        linear-gradient(45deg, transparent 65%, red 80%, transparent 90%),
+        linear-gradient(135deg, transparent 5%, red 15%, transparent 25%),
+        linear-gradient(135deg, transparent 45%, red 55%, transparent 65%),
+        linear-gradient(45deg, transparent 25%, red 35%, transparent 50%);
+      background-size: 8px 2px;
+      background-position: 0 95%;
+      background-repeat: repeat-x;
+    `;
+    styleRegion(this.codeMirror.getCodeMirror(), startIdx, stopIdx, css);
+  }
+
+  clearErrors() {
+    console.log('clearing errors');
+    const css = `
+      background-image: none;
+    `;
     styleAll(this.codeMirror.getCodeMirror(), css);
   }
 
@@ -164,6 +198,7 @@ Editor.propTypes = {
   openLine: PropTypes.number,
   readOnly: PropTypes.bool.isRequired,
   value: PropTypes.string.isRequired,
+  error: CustomPropTypes.error.isRequired,
 };
 
 Editor.defaultProps = {

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -226,7 +226,7 @@ export class SnippetArea extends React.Component {
       filters,
       openLine,
       permissions,
-      error,
+      errors,
       readOnly,
       snippet,
       snippetLanguage,
@@ -268,7 +268,7 @@ export class SnippetArea extends React.Component {
           openLine={openLine}
           readOnly={readOnly}
           value={snippet}
-          error={error}
+          errors={errors}
         />
         <Snackbar
           autoHideDuration={3000}
@@ -318,7 +318,7 @@ const mapStateToProps = (state) => {
     },
     permissions,
     parser: {
-      error,
+      errors,
     },
     user: {
       orgs,
@@ -335,7 +335,7 @@ const mapStateToProps = (state) => {
     snippet,
     snippetTitle,
     permissions,
-    error,
+    errors,
     orgs,
     selectedOrg,
   };

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -226,6 +226,7 @@ export class SnippetArea extends React.Component {
       filters,
       openLine,
       permissions,
+      error,
       readOnly,
       snippet,
       snippetLanguage,
@@ -267,6 +268,7 @@ export class SnippetArea extends React.Component {
           openLine={openLine}
           readOnly={readOnly}
           value={snippet}
+          error={error}
         />
         <Snackbar
           autoHideDuration={3000}
@@ -287,6 +289,7 @@ SnippetArea.propTypes = {
   snippet: PropTypes.string.isRequired,
   snippetTitle: PropTypes.string.isRequired,
   permissions: CustomPropTypes.permissions.isRequired,
+  error: CustomPropTypes.error,
   snippetLanguage: PropTypes.string.isRequired,
   orgs: CustomPropTypes.orgs.isRequired,
   selectedOrg: PropTypes.string,
@@ -295,6 +298,7 @@ SnippetArea.propTypes = {
 SnippetArea.defaultProps = {
   openLine: -1,
   selectedOrg: '',
+  error: null,
 };
 
 const mapStateToProps = (state) => {
@@ -313,6 +317,9 @@ const mapStateToProps = (state) => {
       snippetTitle,
     },
     permissions,
+    parser: {
+      error,
+    },
     user: {
       orgs,
       selectedOrg,
@@ -328,6 +335,7 @@ const mapStateToProps = (state) => {
     snippet,
     snippetTitle,
     permissions,
+    error,
     orgs,
     selectedOrg,
   };

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -289,7 +289,7 @@ SnippetArea.propTypes = {
   snippet: PropTypes.string.isRequired,
   snippetTitle: PropTypes.string.isRequired,
   permissions: CustomPropTypes.permissions.isRequired,
-  error: CustomPropTypes.error,
+  errors: CustomPropTypes.errors,
   snippetLanguage: PropTypes.string.isRequired,
   orgs: CustomPropTypes.orgs.isRequired,
   selectedOrg: PropTypes.string,
@@ -298,7 +298,7 @@ SnippetArea.propTypes = {
 SnippetArea.defaultProps = {
   openLine: -1,
   selectedOrg: '',
-  error: null,
+  errors: [],
 };
 
 const mapStateToProps = (state) => {

--- a/src/reducers/parser.js
+++ b/src/reducers/parser.js
@@ -2,6 +2,7 @@ import * as actions from '../actions/parser';
 
 const initialState = {
   language: '',
+  error: null,
 };
 
 const parser = (state = initialState, action) => {
@@ -13,6 +14,19 @@ const parser = (state = initialState, action) => {
     }
     const language = action.payload;
     return { ...state, language };
+  }
+  case actions.SET_ERROR: {
+    const error = action.payload;
+    return {
+      ...state,
+      error,
+    };
+  }
+  case actions.SET_NO_ERROR: {
+    return {
+      ...state,
+      error: null,
+    };
   }
   default: {
     return state;

--- a/src/reducers/parser.js
+++ b/src/reducers/parser.js
@@ -2,7 +2,7 @@ import * as actions from '../actions/parser';
 
 const initialState = {
   language: '',
-  error: null,
+  errors: [],
 };
 
 const parser = (state = initialState, action) => {
@@ -15,17 +15,17 @@ const parser = (state = initialState, action) => {
     const language = action.payload;
     return { ...state, language };
   }
-  case actions.SET_ERROR: {
-    const error = action.payload;
+  case actions.ADD_ERROR: {
+    const errors = state.errors.concat(action.payload);
     return {
       ...state,
-      error,
+      errors,
     };
   }
-  case actions.SET_NO_ERROR: {
+  case actions.CLEAR_ERRORS: {
     return {
       ...state,
-      error: null,
+      errors: [],
     };
   }
   default: {

--- a/src/util/custom-prop-types.js
+++ b/src/util/custom-prop-types.js
@@ -31,7 +31,7 @@ const snippetData = PropTypes.shape({
   snippetTitle: PropTypes.string,
 });
 
-const error = PropTypes.arrayOf(
+const errors = PropTypes.arrayOf(
   PropTypes.shape({
     type: PropTypes.string,
     begin: PropTypes.number,
@@ -51,5 +51,5 @@ export default {
   orgs,
   permissions,
   snippets,
-  error,
+  errors,
 };

--- a/src/util/custom-prop-types.js
+++ b/src/util/custom-prop-types.js
@@ -31,6 +31,13 @@ const snippetData = PropTypes.shape({
   snippetTitle: PropTypes.string,
 });
 
+const error = PropTypes.shape({
+  type: PropTypes.string,
+  begin: PropTypes.number,
+  end: PropTypes.NaN,
+  msg: PropTypes.string,
+});
+
 const snippets = PropTypes.objectOf(snippetData);
 
 const orgs = PropTypes.arrayOf(PropTypes.string);
@@ -42,4 +49,5 @@ export default {
   orgs,
   permissions,
   snippets,
+  error,
 };

--- a/src/util/custom-prop-types.js
+++ b/src/util/custom-prop-types.js
@@ -31,12 +31,14 @@ const snippetData = PropTypes.shape({
   snippetTitle: PropTypes.string,
 });
 
-const error = PropTypes.shape({
-  type: PropTypes.string,
-  begin: PropTypes.number,
-  end: PropTypes.NaN,
-  msg: PropTypes.string,
-});
+const error = PropTypes.arrayOf(
+  PropTypes.shape({
+    type: PropTypes.string,
+    begin: PropTypes.number,
+    end: PropTypes.NaN,
+    msg: PropTypes.string,
+  }),
+);
 
 const snippets = PropTypes.objectOf(snippetData);
 

--- a/src/util/parser-error-logger.js
+++ b/src/util/parser-error-logger.js
@@ -1,13 +1,19 @@
+import { setError } from '../actions/parser';
+
 const {
   NODE_ENV,
   REACT_APP_ENABLE_PARSER_DEBUGGING,
 } = process.env;
 
-const isDebuggingEnabled =
+const debuggingIsEnabled =
   NODE_ENV === 'development' && REACT_APP_ENABLE_PARSER_DEBUGGING === 'true';
 
-const errorFn =
+const errorFn = (err, dispatch) => {
   /* eslint-disable no-console */
-  isDebuggingEnabled ? (err) => { console.error(err); } : () => {};
+  if (debuggingIsEnabled) console.log(err);
+
+  // Cause red underlining of the error's range
+  dispatch(setError(err));
+};
 
 export default errorFn;

--- a/src/util/parser-error-logger.js
+++ b/src/util/parser-error-logger.js
@@ -1,4 +1,4 @@
-import { setError } from '../actions/parser';
+import { addError } from '../actions/parser';
 
 const {
   NODE_ENV,
@@ -13,7 +13,7 @@ const errorFn = (err, dispatch) => {
   if (debuggingIsEnabled) console.log(err);
 
   // Cause red underlining of the error's range
-  dispatch(setError(err));
+  dispatch(addError(err));
 };
 
 export default errorFn;

--- a/src/workers/parser.js
+++ b/src/workers/parser.js
@@ -1,4 +1,4 @@
-import { LOAD_PARSER, setNoError } from '../actions/parser';
+import { LOAD_PARSER, clearErrors } from '../actions/parser';
 import { PARSE_SNIPPET } from '../actions/app';
 import onError from '../util/parser-error-logger.js';
 import { getRuleCount, rules } from '../util/rules.js';
@@ -14,7 +14,7 @@ self.onmessage = ({ data: action }) => {
   case PARSE_SNIPPET: {
     if (!parser) break;
     const { snippet } = action.payload;
-    self.postMessage(setNoError());
+    self.postMessage(clearErrors());
     const AST = parser(snippet, (err) => onError(err, self.postMessage));
     const ruleCounts = {}; getRuleCount(AST, ruleCounts);
     self.postMessage({

--- a/src/workers/parser.js
+++ b/src/workers/parser.js
@@ -1,4 +1,4 @@
-import { LOAD_PARSER } from '../actions/parser';
+import { LOAD_PARSER, setNoError } from '../actions/parser';
 import { PARSE_SNIPPET } from '../actions/app';
 import onError from '../util/parser-error-logger.js';
 import { getRuleCount, rules } from '../util/rules.js';
@@ -14,6 +14,7 @@ self.onmessage = ({ data: action }) => {
   case PARSE_SNIPPET: {
     if (!parser) break;
     const { snippet } = action.payload;
+    self.postMessage(setNoError());
     const AST = parser(snippet, (err) => onError(err, self.postMessage));
     const ruleCounts = {}; getRuleCount(AST, ruleCounts);
     self.postMessage({

--- a/src/workers/parser.js
+++ b/src/workers/parser.js
@@ -14,7 +14,7 @@ self.onmessage = ({ data: action }) => {
   case PARSE_SNIPPET: {
     if (!parser) break;
     const { snippet } = action.payload;
-    const AST = parser(snippet, onError);
+    const AST = parser(snippet, (err) => onError(err, self.postMessage));
     const ruleCounts = {}; getRuleCount(AST, ruleCounts);
     self.postMessage({
       type: action.type,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PRs adds the errors produced by the parser to the app's redux state. These errors are used by `<Editor />` to underline the erroneous regions with a red wiggly line.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #143. The users should be able to see where the errors in their code are.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
### With Errors
![screen shot 2017-04-27 at 2 43 53 pm](https://cloud.githubusercontent.com/assets/10351828/25501366/1ed0892a-2b58-11e7-959c-5fdd1f1c7114.png)

### With No Errors
![screen shot 2017-04-27 at 2 44 15 pm](https://cloud.githubusercontent.com/assets/10351828/25501365/1ecd889c-2b58-11e7-8e4b-0dc33be5e0f3.png)

