### PR TITLE
Fix login button centering

### DIFF
--- a/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
+++ b/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
@@ -74,11 +74,7 @@ exports[`<CodesplainAppBar /> snapshot tests user is not logged in 1`] = `
       <LoginButton
         onClick={[Function]} />
     }
-    iconStyleRight={
-      Object {
-        "marginTop": "16px",
-      }
-    }
+    iconStyleRight={Object {}}
     showMenuIconButton={false}
     title={
       <span

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -74,10 +74,12 @@ export class CodesplainAppBar extends Component {
   }
 
   handleSignOut() {
+    const { router } = this.props;
     cookie.remove('token', { path: '/' });
     cookie.remove('username', { path: '/' });
     cookie.remove('userAvatarURL', { path: '/' });
     this.setState({ isLoggedIn: false });
+    router.push('/');
     location.reload();
   }
 

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -141,7 +141,8 @@ export class CodesplainAppBar extends Component {
     ];
 
     const { userSnippets } = this.props;
-    const rightElement = this.state.isLoggedIn ?
+    const { isDialogOpen, isLoggedIn } = this.state;
+    const rightElement = isLoggedIn ?
       (<AppMenu
         onSignOut={this.handleSignOut}
         onTitleClicked={this.handleSnippetSelected}
@@ -163,12 +164,12 @@ export class CodesplainAppBar extends Component {
           showMenuIconButton={false}
           title={titleElement}
           iconElementRight={rightElement}
-          iconStyleRight={styles.rightElement}
+          iconStyleRight={isLoggedIn ? styles.rightElement : {}}
         />
         <Dialog
           actions={actions}
           modal={false}
-          open={this.state.isDialogOpen}
+          open={isDialogOpen}
           onRequestClose={this.handleDialogClose}
         >
           Discard unsaved changes?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This centers the login button in the AppBar

## Motivation and Context
The login button isn't centered

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
<img width="84" alt="screen shot 2017-04-27 at 4 07 36 pm" src="https://cloud.githubusercontent.com/assets/10211603/25504455/a9839d7c-2b63-11e7-8484-9054bbd73214.png">
