### PR TITLE
Improve Tooltips (especially in Chrome)

### DIFF
--- a/__tests__/components/__snapshots__/LockButton.test.jsx.snap
+++ b/__tests__/components/__snapshots__/LockButton.test.jsx.snap
@@ -4,24 +4,45 @@ exports[`<LockButton /> matches snapshot of when the app is in read-only mode 1`
     Object {
       "height": "48px",
     }
-  }
-  title="Switching back to edit mode not supported yet">
-  <IconButton
-    disableTouchRipple={false}
-    disabled={true}
-    iconStyle={Object {}}
-    id="lockButton"
-    label="Switch to edit mode"
-    onTouchTap={[Function]}
+  }>
+  <div
+    data-for="lock-tip"
+    data-tip={true}
     style={
       Object {
-        "zIndex": 5,
+        "display": "inline-block",
       }
-    }
-    tooltipPosition="bottom-center"
-    touch={false}>
-    <ActionLock />
-  </IconButton>
+    }>
+    <IconButton
+      disableTouchRipple={false}
+      disabled={true}
+      iconStyle={Object {}}
+      id="lockButton"
+      label="Switch to edit mode"
+      onTouchTap={[Function]}
+      style={
+        Object {
+          "zIndex": 5,
+        }
+      }
+      tooltipPosition="bottom-center"
+      touch={false}>
+      <ActionLock />
+    </IconButton>
+  </div>
+  <ReactTooltip
+    effect="solid"
+    id="lock-tip"
+    insecure={true}
+    place="bottom"
+    resizeHide={true}
+    wrapper="div">
+    <span>
+      Switching back to edit mode
+      <br />
+      not supported yet
+    </span>
+  </ReactTooltip>
 </span>
 `;
 
@@ -31,23 +52,44 @@ exports[`<LockButton /> matches snapshot of when the app is not in read-only mod
     Object {
       "height": "48px",
     }
-  }
-  title="Click to lock the snippet (this will prevent further changes.)">
-  <IconButton
-    disableTouchRipple={false}
-    disabled={false}
-    iconStyle={Object {}}
-    id="lockButton"
-    label="Switch to read-only mode"
-    onTouchTap={[Function]}
+  }>
+  <div
+    data-for="lock-tip"
+    data-tip={true}
     style={
       Object {
-        "zIndex": 5,
+        "display": "inline-block",
       }
-    }
-    tooltipPosition="bottom-center"
-    touch={false}>
-    <ActionLockOpen />
-  </IconButton>
+    }>
+    <IconButton
+      disableTouchRipple={false}
+      disabled={false}
+      iconStyle={Object {}}
+      id="lockButton"
+      label="Switch to read-only mode"
+      onTouchTap={[Function]}
+      style={
+        Object {
+          "zIndex": 5,
+        }
+      }
+      tooltipPosition="bottom-center"
+      touch={false}>
+      <ActionLockOpen />
+    </IconButton>
+  </div>
+  <ReactTooltip
+    effect="solid"
+    id="lock-tip"
+    insecure={true}
+    place="bottom"
+    resizeHide={true}
+    wrapper="div">
+    <span>
+      Click to lock the snippet
+      <br />
+      (this will prevent further changes.)
+    </span>
+  </ReactTooltip>
 </span>
 `;

--- a/__tests__/components/__snapshots__/SaveMenu.test.jsx.snap
+++ b/__tests__/components/__snapshots__/SaveMenu.test.jsx.snap
@@ -5,73 +5,92 @@ exports[`<SaveMenu /> snapshot tests matches default snapshot 1`] = `
       "height": "48px",
     }
   }>
-  <IconMenu
-    anchorOrigin={
-      Object {
-        "horizontal": "left",
-        "vertical": "top",
-      }
-    }
-    animated={true}
-    iconButtonElement={
-      <IconButton
-        disableTouchRipple={false}
-        disabled={false}
-        iconStyle={Object {}}
-        title="Save Options"
-        tooltipPosition="bottom-center"
-        touch={false}>
-        <ContentSave />
-      </IconButton>
-    }
-    id="menu"
-    multiple={false}
-    onItemTouchTap={[Function]}
-    onKeyboardFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onRequestChange={[Function]}
-    onTouchTap={[Function]}
-    open={null}
-    targetOrigin={
-      Object {
-        "horizontal": "left",
-        "vertical": "top",
-      }
-    }
-    touchTapCloseDelay={200}
-    useLayerForClickAway={false}>
-    <MenuItem
-      anchorOrigin={
+  <span>
+    <div
+      data-for="save-tip"
+      data-tip={true}
+      style={
         Object {
-          "horizontal": "right",
-          "vertical": "top",
+          "display": "inline-block",
         }
-      }
-      checked={false}
-      desktop={false}
-      disabled={false}
-      focusState="none"
-      insetChildren={false}
-      onTouchTap={[Function]}
-      primaryText="Save" />
-    <MenuItem
-      anchorOrigin={
-        Object {
-          "horizontal": "right",
-          "vertical": "top",
+      }>
+      <IconMenu
+        anchorOrigin={
+          Object {
+            "horizontal": "left",
+            "vertical": "top",
+          }
         }
-      }
-      checked={false}
-      desktop={false}
-      disabled={false}
-      focusState="none"
-      insetChildren={false}
-      onTouchTap={[Function]}
-      primaryText="Save As" />
-  </IconMenu>
+        animated={true}
+        iconButtonElement={
+          <IconButton
+            disableTouchRipple={false}
+            disabled={false}
+            iconStyle={Object {}}
+            tooltipPosition="bottom-center"
+            touch={false}>
+            <ContentSave />
+          </IconButton>
+        }
+        id="menu"
+        multiple={false}
+        onItemTouchTap={[Function]}
+        onKeyboardFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onRequestChange={[Function]}
+        onTouchTap={[Function]}
+        open={null}
+        targetOrigin={
+          Object {
+            "horizontal": "left",
+            "vertical": "top",
+          }
+        }
+        touchTapCloseDelay={200}
+        useLayerForClickAway={false}>
+        <MenuItem
+          anchorOrigin={
+            Object {
+              "horizontal": "right",
+              "vertical": "top",
+            }
+          }
+          checked={false}
+          desktop={false}
+          disabled={false}
+          focusState="none"
+          insetChildren={false}
+          onTouchTap={[Function]}
+          primaryText="Save" />
+        <MenuItem
+          anchorOrigin={
+            Object {
+              "horizontal": "right",
+              "vertical": "top",
+            }
+          }
+          checked={false}
+          desktop={false}
+          disabled={false}
+          focusState="none"
+          insetChildren={false}
+          onTouchTap={[Function]}
+          primaryText="Save As" />
+      </IconMenu>
+    </div>
+    <ReactTooltip
+      effect="solid"
+      id="save-tip"
+      insecure={true}
+      place="bottom"
+      resizeHide={true}
+      wrapper="div">
+      Save Options
+    </ReactTooltip>
+  </span>
   <Dialog
     actions={
       <span>
@@ -139,73 +158,92 @@ exports[`<SaveMenu /> snapshot tests matches snapshot when saving is not enabled
       "height": "48px",
     }
   }>
-  <IconMenu
-    anchorOrigin={
-      Object {
-        "horizontal": "left",
-        "vertical": "top",
-      }
-    }
-    animated={true}
-    iconButtonElement={
-      <IconButton
-        disableTouchRipple={false}
-        disabled={true}
-        iconStyle={Object {}}
-        title="Login to Save"
-        tooltipPosition="bottom-center"
-        touch={false}>
-        <ContentSave />
-      </IconButton>
-    }
-    id="menu"
-    multiple={false}
-    onItemTouchTap={[Function]}
-    onKeyboardFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onRequestChange={[Function]}
-    onTouchTap={[Function]}
-    open={null}
-    targetOrigin={
-      Object {
-        "horizontal": "left",
-        "vertical": "top",
-      }
-    }
-    touchTapCloseDelay={200}
-    useLayerForClickAway={false}>
-    <MenuItem
-      anchorOrigin={
+  <span>
+    <div
+      data-for="save-tip"
+      data-tip={true}
+      style={
         Object {
-          "horizontal": "right",
-          "vertical": "top",
+          "display": "inline-block",
         }
-      }
-      checked={false}
-      desktop={false}
-      disabled={false}
-      focusState="none"
-      insetChildren={false}
-      onTouchTap={[Function]}
-      primaryText="Save" />
-    <MenuItem
-      anchorOrigin={
-        Object {
-          "horizontal": "right",
-          "vertical": "top",
+      }>
+      <IconMenu
+        anchorOrigin={
+          Object {
+            "horizontal": "left",
+            "vertical": "top",
+          }
         }
-      }
-      checked={false}
-      desktop={false}
-      disabled={false}
-      focusState="none"
-      insetChildren={false}
-      onTouchTap={[Function]}
-      primaryText="Save As" />
-  </IconMenu>
+        animated={true}
+        iconButtonElement={
+          <IconButton
+            disableTouchRipple={false}
+            disabled={true}
+            iconStyle={Object {}}
+            tooltipPosition="bottom-center"
+            touch={false}>
+            <ContentSave />
+          </IconButton>
+        }
+        id="menu"
+        multiple={false}
+        onItemTouchTap={[Function]}
+        onKeyboardFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onRequestChange={[Function]}
+        onTouchTap={[Function]}
+        open={null}
+        targetOrigin={
+          Object {
+            "horizontal": "left",
+            "vertical": "top",
+          }
+        }
+        touchTapCloseDelay={200}
+        useLayerForClickAway={false}>
+        <MenuItem
+          anchorOrigin={
+            Object {
+              "horizontal": "right",
+              "vertical": "top",
+            }
+          }
+          checked={false}
+          desktop={false}
+          disabled={false}
+          focusState="none"
+          insetChildren={false}
+          onTouchTap={[Function]}
+          primaryText="Save" />
+        <MenuItem
+          anchorOrigin={
+            Object {
+              "horizontal": "right",
+              "vertical": "top",
+            }
+          }
+          checked={false}
+          desktop={false}
+          disabled={false}
+          focusState="none"
+          insetChildren={false}
+          onTouchTap={[Function]}
+          primaryText="Save As" />
+      </IconMenu>
+    </div>
+    <ReactTooltip
+      effect="solid"
+      id="save-tip"
+      insecure={true}
+      place="bottom"
+      resizeHide={true}
+      wrapper="div">
+      Login to Save
+    </ReactTooltip>
+  </span>
   <Dialog
     actions={
       <span>
@@ -273,73 +311,92 @@ exports[`<SaveMenu /> snapshot tests matches snapshot when user cannot save 1`] 
       "height": "48px",
     }
   }>
-  <IconMenu
-    anchorOrigin={
-      Object {
-        "horizontal": "left",
-        "vertical": "top",
-      }
-    }
-    animated={true}
-    iconButtonElement={
-      <IconButton
-        disableTouchRipple={false}
-        disabled={false}
-        iconStyle={Object {}}
-        title="Save Options"
-        tooltipPosition="bottom-center"
-        touch={false}>
-        <ContentSave />
-      </IconButton>
-    }
-    id="menu"
-    multiple={false}
-    onItemTouchTap={[Function]}
-    onKeyboardFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onRequestChange={[Function]}
-    onTouchTap={[Function]}
-    open={null}
-    targetOrigin={
-      Object {
-        "horizontal": "left",
-        "vertical": "top",
-      }
-    }
-    touchTapCloseDelay={200}
-    useLayerForClickAway={false}>
-    <MenuItem
-      anchorOrigin={
+  <span>
+    <div
+      data-for="save-tip"
+      data-tip={true}
+      style={
         Object {
-          "horizontal": "right",
-          "vertical": "top",
+          "display": "inline-block",
         }
-      }
-      checked={false}
-      desktop={false}
-      disabled={true}
-      focusState="none"
-      insetChildren={false}
-      onTouchTap={[Function]}
-      primaryText="Save" />
-    <MenuItem
-      anchorOrigin={
-        Object {
-          "horizontal": "right",
-          "vertical": "top",
+      }>
+      <IconMenu
+        anchorOrigin={
+          Object {
+            "horizontal": "left",
+            "vertical": "top",
+          }
         }
-      }
-      checked={false}
-      desktop={false}
-      disabled={false}
-      focusState="none"
-      insetChildren={false}
-      onTouchTap={[Function]}
-      primaryText="Save As" />
-  </IconMenu>
+        animated={true}
+        iconButtonElement={
+          <IconButton
+            disableTouchRipple={false}
+            disabled={false}
+            iconStyle={Object {}}
+            tooltipPosition="bottom-center"
+            touch={false}>
+            <ContentSave />
+          </IconButton>
+        }
+        id="menu"
+        multiple={false}
+        onItemTouchTap={[Function]}
+        onKeyboardFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onRequestChange={[Function]}
+        onTouchTap={[Function]}
+        open={null}
+        targetOrigin={
+          Object {
+            "horizontal": "left",
+            "vertical": "top",
+          }
+        }
+        touchTapCloseDelay={200}
+        useLayerForClickAway={false}>
+        <MenuItem
+          anchorOrigin={
+            Object {
+              "horizontal": "right",
+              "vertical": "top",
+            }
+          }
+          checked={false}
+          desktop={false}
+          disabled={true}
+          focusState="none"
+          insetChildren={false}
+          onTouchTap={[Function]}
+          primaryText="Save" />
+        <MenuItem
+          anchorOrigin={
+            Object {
+              "horizontal": "right",
+              "vertical": "top",
+            }
+          }
+          checked={false}
+          desktop={false}
+          disabled={false}
+          focusState="none"
+          insetChildren={false}
+          onTouchTap={[Function]}
+          primaryText="Save As" />
+      </IconMenu>
+    </div>
+    <ReactTooltip
+      effect="solid"
+      id="save-tip"
+      insecure={true}
+      place="bottom"
+      resizeHide={true}
+      wrapper="div">
+      Save Options
+    </ReactTooltip>
+  </span>
   <Dialog
     actions={
       <span>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-router": "^3.0.2",
     "react-scripts": "^0.9.5",
     "react-tap-event-plugin": "^2.0.1",
+    "react-tooltip": "^3.3.0",
     "redux": "^3.6.0",
     "redux-mock-store": "^1.2.2",
     "redux-thunk": "^2.2.0",

--- a/src/components/buttons/LockButton.jsx
+++ b/src/components/buttons/LockButton.jsx
@@ -3,6 +3,7 @@ import React, { PropTypes } from 'react';
 import IconButton from 'material-ui/IconButton';
 import Lock from 'material-ui/svg-icons/action/lock';
 import LockOpen from 'material-ui/svg-icons/action/lock-open';
+import ReactTooltip from 'react-tooltip';
 
 const styles = {
   button: {
@@ -17,16 +18,21 @@ const LockButton = ({ onClick, readOnly }) => {
   const lockIcon = readOnly ? <Lock /> : <LockOpen />;
   const toolTipText = readOnly ? 'Switching back to edit mode not supported yet' : 'Click to lock the snippet (this will prevent further changes.)';
   return (
-    <span style={styles.buttonContainer} title={toolTipText}>
+    <span style={styles.buttonContainer}>
       <IconButton
         id="lockButton"
         disabled={readOnly}
+        data-tip
+        data-for="lock-tip"
         label={`Switch to ${readOnly ? 'edit' : 'read-only'} mode`}
         onTouchTap={onClick}
         style={styles.button}
       >
         {lockIcon}
       </IconButton>
+      <ReactTooltip id="lock-tip" effect="solid">
+        {toolTipText}
+      </ReactTooltip>
     </span>
   );
 };

--- a/src/components/buttons/LockButton.jsx
+++ b/src/components/buttons/LockButton.jsx
@@ -12,25 +12,51 @@ const styles = {
   buttonContainer: {
     height: '48px',
   },
+  inlineBlock: {
+    display: 'inline-block',
+  },
 };
 
 const LockButton = ({ onClick, readOnly }) => {
   const lockIcon = readOnly ? <Lock /> : <LockOpen />;
-  const toolTipText = readOnly ? 'Switching back to edit mode not supported yet' : 'Click to lock the snippet (this will prevent further changes.)';
+
+  // These should be left as spans with breaks, or the tool
+  // tip's positioning will sometimes be off
+  const toolTipText = readOnly ?
+    (<span>
+      Switching back to edit mode
+      <br />
+      not supported yet
+    </span>)
+    :
+    (<span>
+      Click to lock the snippet
+      <br />
+      (this will prevent further changes.)
+    </span>);
+
   return (
     <span style={styles.buttonContainer}>
-      <IconButton
-        id="lockButton"
-        disabled={readOnly}
+      <div
+        style={styles.inlineBlock}
         data-tip
         data-for="lock-tip"
-        label={`Switch to ${readOnly ? 'edit' : 'read-only'} mode`}
-        onTouchTap={onClick}
-        style={styles.button}
       >
-        {lockIcon}
-      </IconButton>
-      <ReactTooltip id="lock-tip" effect="solid">
+        <IconButton
+          id="lockButton"
+          disabled={readOnly}
+          label={`Switch to ${readOnly ? 'edit' : 'read-only'} mode`}
+          onTouchTap={onClick}
+          style={styles.button}
+        >
+          {lockIcon}
+        </IconButton>
+      </div>
+      <ReactTooltip
+        id="lock-tip"
+        effect="solid"
+        place="bottom"
+      >
         {toolTipText}
       </ReactTooltip>
     </span>

--- a/src/components/menus/SaveMenu.jsx
+++ b/src/components/menus/SaveMenu.jsx
@@ -17,25 +17,16 @@ const styles = {
   container: {
     height: '48px',
   },
+  inlineBlock: {
+    display: 'inline-block',
+  },
 };
 
 const saveIconButton = disabled => (
-  <span>
-    <div
-      data-tip
-      data-for="save-tip"
-    >
-      <IconButton
-        disabled={disabled}
-      >
-        <SaveIcon />
-      </IconButton>
-    </div>
-    <ReactTooltip id="save-tip" effect="solid">
-      {disabled ? 'Login to Save' : 'Save Options'}
-    </ReactTooltip>
-  </span>
-);
+  <IconButton disabled={disabled}>
+    <SaveIcon />
+  </IconButton>
+)
 
 class SaveMenu extends React.Component {
   constructor(props) {
@@ -54,21 +45,41 @@ class SaveMenu extends React.Component {
       enabled,
       onSaveClick,
     } = this.props;
+
+    // These should be strings, not spans, or the tool tip's
+    // positioning will sometimes be off
+    const toolTipText = enabled ? 'Save Options' : 'Login to Save';
+
     return (
-      <IconMenu
-        id="menu"
-        iconButtonElement={saveIconButton(!enabled)}
-      >
-        <MenuItem
-          onTouchTap={onSaveClick}
-          disabled={!canSave}
-          primaryText="Save"
-        />
-        <MenuItem
-          onTouchTap={() => this.setState({ showSaveAsDialog: true })}
-          primaryText="Save As"
-        />
-      </IconMenu>
+      <span>
+        <div
+          style={styles.inlineBlock}
+          data-tip
+          data-for="save-tip"
+        >
+          <IconMenu
+            id="menu"
+            iconButtonElement={saveIconButton(!enabled)}
+          >
+            <MenuItem
+              onTouchTap={onSaveClick}
+              disabled={!canSave}
+              primaryText="Save"
+            />
+            <MenuItem
+              onTouchTap={() => this.setState({ showSaveAsDialog: true })}
+              primaryText="Save As"
+            />
+          </IconMenu>
+        </div>
+        <ReactTooltip
+          id="save-tip"
+          effect="solid"
+          place="bottom"
+        >
+          {toolTipText}
+        </ReactTooltip>
+      </span>
     );
   }
 

--- a/src/components/menus/SaveMenu.jsx
+++ b/src/components/menus/SaveMenu.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import ReactTooltip from 'react-tooltip';
 import {
   IconButton,
   IconMenu,
@@ -19,12 +20,21 @@ const styles = {
 };
 
 const saveIconButton = disabled => (
-  <IconButton
-    disabled={disabled}
-    title={disabled ? 'Login to Save' : 'Save Options'}
-  >
-    <SaveIcon />
-  </IconButton>
+  <span>
+    <div
+      data-tip
+      data-for="save-tip"
+    >
+      <IconButton
+        disabled={disabled}
+      >
+        <SaveIcon />
+      </IconButton>
+    </div>
+    <ReactTooltip id="save-tip" effect="solid">
+      {disabled ? 'Login to Save' : 'Save Options'}
+    </ReactTooltip>
+  </span>
 );
 
 class SaveMenu extends React.Component {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,7 +1208,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.2.5:
+classnames@^2.2.0, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -2301,7 +2301,7 @@ fb-watchman@^1.8.0, fb-watchman@^1.9.0:
   dependencies:
     bser "1.0.2"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.6:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.6, fbjs@^0.8.9:
   version "0.8.11"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.11.tgz#340b590b8a2278a01ef7467c07a16da9b753db24"
   dependencies:
@@ -4560,6 +4560,12 @@ promise@7.1.1, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 proxy-addr@~1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
@@ -4788,6 +4794,13 @@ react-test-renderer@^15.4.2:
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
+
+react-tooltip@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.3.0.tgz#51c08ae0221075e2c43d83cd47fc78466612df7d"
+  dependencies:
+    classnames "^2.2.0"
+    prop-types "^15.5.8"
 
 react@^15.4.2:
   version "15.4.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes the button tool tips from `title` HTML attributes to `ReactTooltip` components. This causes them to (1) look better, and (2) be far more responsive.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #390. The button tooltips take a couple of seconds to appear in chrome as `title` attributes, but display instantly when implemented as `ReactTooltip`s.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
### Full Width
<img width="750" alt="screen shot 2017-04-27 at 8 38 51 pm" src="https://cloud.githubusercontent.com/assets/10351828/25511216/1dd6ea86-2b8b-11e7-9f7d-aabdc1610085.png">
<img width="750" alt="screen shot 2017-04-27 at 8 38 59 pm" src="https://cloud.githubusercontent.com/assets/10351828/25511221/1dd98336-2b8b-11e7-9594-de415fe4a523.png">

### Medium Width
<img width="500" alt="screen shot 2017-04-27 at 8 39 16 pm" src="https://cloud.githubusercontent.com/assets/10351828/25511217/1dd7daf4-2b8b-11e7-90b6-d65c5d43a499.png">
<img width="500" alt="screen shot 2017-04-27 at 8 39 22 pm" src="https://cloud.githubusercontent.com/assets/10351828/25511219/1dd8f4c0-2b8b-11e7-82d9-2492a71bea42.png">

### Small Width
<img width="400" alt="screen shot 2017-04-27 at 8 39 32 pm" src="https://cloud.githubusercontent.com/assets/10351828/25511218/1dd8db52-2b8b-11e7-9528-39a5726f48a8.png">
<img width="400" alt="screen shot 2017-04-27 at 8 39 39 pm" src="https://cloud.githubusercontent.com/assets/10351828/25511220/1dd94114-2b8b-11e7-8096-676ebff4a56f.png">


## Notes
I have spent a lot of time fiddling with the JSX & CSS for this PR. I believe I have managed to work out most of the display/positioning kinks in the new tool tips. Note, however, that occasionally (at smaller screen widths), the Save button's tool tip will be pushed a bit too far right:

<img width="319" alt="screen shot 2017-04-27 at 8 27 09 pm" src="https://cloud.githubusercontent.com/assets/10351828/25511163/cd1146b4-2b8a-11e7-9ee0-94793461f584.png">

I have been unable to fix this. I do not think it is a severe (or common) enough issue to warrant any more time spent on trying to resolve it (*ahem, Dane 😁 )