### PR TITLE
Fix issue with reading organizations from cookies

### DIFF
--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -56,7 +56,7 @@ export class AppBody extends Component {
       dispatch(switchOrg(savedUsername));
 
       // If they are a member of any organizations, add to list as well
-      cookie.load('orgs').split().forEach(org => dispatch(addOrg(org)));
+      cookie.load('orgs').split(' ').forEach(org => dispatch(addOrg(org)));
     }
 
     if (!username && !snippetKey) {

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -77,6 +77,7 @@ export class CodesplainAppBar extends Component {
     const { router } = this.props;
     cookie.remove('token', { path: '/' });
     cookie.remove('username', { path: '/' });
+    cookie.remove('orgs', { path: '/' });
     cookie.remove('userAvatarURL', { path: '/' });
     this.setState({ isLoggedIn: false });
     router.push('/');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the `' '` in `split()`

## Motivation and Context
To read organizations from cookies correctly

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed