### PR TITLE
Use tags array in highlight function

### DIFF
--- a/__tests__/util/codemirror-utils.test.js
+++ b/__tests__/util/codemirror-utils.test.js
@@ -83,7 +83,7 @@ describe('util: codemirror-utils', () => {
   describe('highlightNode()', () => {
     it('should not call styleRegion if a rule is not ignored or valid', () => {
       const node = {
-        type: 'Blips and Chitz',
+        tags: ['Blips and Chitz'],
       };
       codemirrorUtils.highlightNode(codeMirror, node, {}, '');
       expect(codeMirror.markText).not.toBeCalled();
@@ -91,11 +91,26 @@ describe('util: codemirror-utils', () => {
 
     it('should not call styleRegion for a node if its type is ignored', () => {
       const node = {
-        type: 'suite',
+        tags: ['suite'],
         children: [],
       };
       codemirrorUtils.highlightNode(codeMirror, node, {}, 'blue');
       expect(codeMirror.markText).not.toBeCalled();
+    });
+
+    it('should call styleRegion for a node if its type is not ignored', () => {
+      const node = {
+        tags: ['suite'],
+        children: [],
+      };
+      codemirrorUtils.setRules({
+        'suite': {
+          color: '#ffffff',
+          prettyName: 'Suite',
+        },
+      });
+      codemirrorUtils.highlightNode(codeMirror, node, {}, 'blue');
+      expect(codeMirror.markText).toBeCalled();
     });
   });
 

--- a/src/util/codemirror-utils.js
+++ b/src/util/codemirror-utils.js
@@ -35,7 +35,11 @@ export function highlightNode(codeMirror, node, filters, parentColor) {
 
   // If we aren't ignoring this token...
   if (ignoredRules.indexOf(node.type) === -1) {
-    const rule = rules[node.type]; // Get the rule obj for this rule
+    // Node's type is the last element of the node's tags property
+    const type = node.tags[node.tags.length - 1];
+
+    // Get the rule obj for this rule
+    const rule = rules[type];
     if (!rule) {
       return; // Remove this return and the highlighting will sometimes fail
     }
@@ -45,7 +49,7 @@ export function highlightNode(codeMirror, node, filters, parentColor) {
     }
 
     // If this token's filter is not selected
-    if (!filters[node.type] || !filters[node.type].selected) {
+    if (!filters[type] || !filters[type].selected) {
       color = parentColor;
     }
 

--- a/src/util/codemirror-utils.js
+++ b/src/util/codemirror-utils.js
@@ -32,12 +32,11 @@ exported wrapper func for this, and starts the recursion.
 */
 export function highlightNode(codeMirror, node, filters, parentColor) {
   let color = parentColor;
+  // Node's type is the last element of the node's tags property
+  const type = _.takeRight(node.tags);
 
   // If we aren't ignoring this token...
-  if (ignoredRules.indexOf(node.type) === -1) {
-    // Node's type is the last element of the node's tags property
-    const type = node.tags[node.tags.length - 1];
-
+  if (ignoredRules.indexOf(type) === -1) {
     // Get the rule obj for this rule
     const rule = rules[type];
     if (!rule) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR causes the highlighting function to use the last element of a node's `tags` array property as its type. This change depends on the parser updates introduced in https://github.com/maryvilledev/codesplain/pull/76#pullrequestreview-35816890, so https://github.com/maryvilledev/codesplain/pull/76#pullrequestreview-35816890 should be merged before this PR.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #442. We want more specific information about certain nodes, such as function calls and boolean values.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
