### PR TITLE
Fix redirects to Home page from Not Found page

### DIFF
--- a/src/components/NotFound.jsx
+++ b/src/components/NotFound.jsx
@@ -5,6 +5,7 @@ import {
   CardTitle,
   FlatButton,
 } from 'material-ui';
+import { withRouter } from 'react-router';
 
 const styles = {
   card: {
@@ -15,7 +16,7 @@ const styles = {
   },
 };
 
-const NotFound = () => (
+const NotFound = ({ router }) => (
   <Card
     style={styles.card}
   >
@@ -26,11 +27,11 @@ const NotFound = () => (
       <FlatButton
         fullWidth
         label="Home"
-        onTouchTap={() => { window.location = '/'; }}
+        onTouchTap={() => router.push('/')}
         primary
       />
     </CardActions>
   </Card>
 );
 
-export default NotFound;
+export default withRouter(NotFound);

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -41,16 +41,9 @@ export class AppBody extends Component {
   }
 
   componentDidMount() {
-    const {
-      dispatch,
-      router,
-    } = this.props;
-    const {
-      id: snippetKey,
-      username,
-    } = router.params;
+    const { dispatch } = this.props;
 
-    // If the user is authenticated, add her Github to the orgs, and make it
+    // If the user is authenticated, add their Github to the orgs, and make it
     // the selected value
     if (cookie.load('token') && cookie.load('username')) {
       const savedUsername = cookie.load('username');
@@ -61,6 +54,29 @@ export class AppBody extends Component {
       cookie.load('orgs').split(' ').forEach(org => dispatch(addOrg(org)));
     }
 
+    this.loadSnippet();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // Reload snippet if URL changes. Assume it is valid, and
+    // if it is not, the call to loadSnippet will handle it.
+    if (this.state.pathname !== nextProps.router.location.pathname) {
+      this.setState({ isValidSnippet: true });
+      this.loadSnippet();
+    }
+  }
+
+  loadSnippet() {
+    const {
+      dispatch,
+      router,
+    } = this.props;
+    const {
+      id: snippetKey,
+      username,
+    } = router.params;
+
+    this.setState({ pathname: router.location.pathname });
     if (!username && !snippetKey) {
       // This is a new snippet for the current user, enable all permissions
       const permissions = {
@@ -81,19 +97,6 @@ export class AppBody extends Component {
 
     // Restore the user's credentials into state
     dispatch(restoreUserCredentials(cookie.load('token'), cookie.load('username')));
-
-    this.loadSnippet();
-  }
-
-  loadSnippet() {
-    const {
-      dispatch,
-      router,
-    } = this.props;
-    const {
-      id: snippetKey,
-      username,
-    } = router.params;
 
     dispatch(loadSnippet(username, snippetKey))
       .then((res) => {

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -37,7 +37,9 @@ export class AppBody extends Component {
     this.state = {
       isValidSnippet: true,
     };
+    this.loadSnippet = this.loadSnippet.bind(this);
   }
+
   componentDidMount() {
     const {
       dispatch,
@@ -79,6 +81,19 @@ export class AppBody extends Component {
 
     // Restore the user's credentials into state
     dispatch(restoreUserCredentials(cookie.load('token'), cookie.load('username')));
+
+    this.loadSnippet();
+  }
+
+  loadSnippet() {
+    const {
+      dispatch,
+      router,
+    } = this.props;
+    const {
+      id: snippetKey,
+      username,
+    } = router.params;
 
     dispatch(loadSnippet(username, snippetKey))
       .then((res) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Convert `<NotFound />` to use `router.push` instead of `window.location`.
* Cause `<AppBody />` to run its snippet loading logic not only when first mounted, but also when the URL path changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #450. Prior to this change, clicking on the header from the Not Found page would not take you back to the Home screen, despite the URL changing. This was due to using `router.push('/')` to handle redirects when the header was clicked, which resulted in `<AppBody />`'s state persisting across renders. This included the `isValidSnippet` state variable, which would have been set to false, and prevented the normal Home screen from displaying.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
