### PR TITLE
Added ability to save as an org

### DIFF
--- a/src/components/menus/SaveMenu.jsx
+++ b/src/components/menus/SaveMenu.jsx
@@ -26,7 +26,7 @@ const saveIconButton = disabled => (
   <IconButton disabled={disabled}>
     <SaveIcon />
   </IconButton>
-)
+);
 
 class SaveMenu extends React.Component {
   constructor(props) {

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -112,8 +112,8 @@ export class AppBody extends Component {
 
         const permissions = {
           canRead: true,
-          // Currently, users may only edit a file they own
-          canEdit: (username === cookie.load('username')),
+          canEdit: (username === cookie.load('username') ||
+           cookie.load('orgs').split(' ').includes(username)),
         };
         dispatch(setPermissions(permissions));
 

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -110,10 +110,16 @@ export class AppBody extends Component {
         // Restore the application's state
         dispatch(restoreState(appState));
 
+        // If the user is a member of the org in question, make the org the
+        // current org
+        const isMember = cookie.load('orgs').split(' ').includes(username);
+        if (isMember) {
+          dispatch(switchOrg(username));
+        }
+
         const permissions = {
           canRead: true,
-          canEdit: (username === cookie.load('username') ||
-           cookie.load('orgs').split(' ').includes(username)),
+          canEdit: (username === cookie.load('username') || isMember),
         };
         dispatch(setPermissions(permissions));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes bug where a user cannot save to a snippet owned by an org she is a member of.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
