### PR TITLE
Fix issue with right panel resizing

### DIFF
--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -30,7 +30,7 @@ const styles = {
     display: 'flex',
     flexFlow: 'column nowrap',
     height: '100%',
-    flex: '1 1 auto',
+    flex: '2 1',
     overflowY: 'auto',
     boxShadow: '0px 1px 6px rgba(0, 0, 0, 0.12), 0px 1px 4px rgba(0, 0, 0, 0.12)',
   },


### PR DESCRIPTION
## Description
Sets the flex properties for the right panel in AppBody

## Motivation and Context
The panel will resize based on the number of filters present, which can be inconsisten

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
