### PR TITLE
Don't encode periods; Make charCodes uppercase

### DIFF
--- a/src/util/requests.js
+++ b/src/util/requests.js
@@ -3,10 +3,10 @@ const API_URL = process.env.REACT_APP_API_URL;
 // encodeURIComponent does not convert all URI-unfriendly characters, necessitating
 // and enhanced encoding function
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#Return_value
-export const sanitizeKey = str => (
-  encodeURIComponent(str)
-    .replace(/[!'.()*]/g, ch => `%${ch.charCodeAt(0).toString(16)}`)
-);
+export const sanitizeKey = (str) => {
+  const getCharCode = ch => `%${ch.charCodeAt(0).toString(16).toUpperCase()}`;
+  return encodeURIComponent(str).replace(/[!'()*]/g, ch => getCharCode(ch));
+};
 
 /* Construct the endpoint to make a REST request to. Only the username is
  * field is required; the snippetId will be left blank for POST requests,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR prevents periods from being encoded, and causes character codes to be made uppercase (`%2a` -> `%2A`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #451. Allows for funky silly snippet titles with unsafe URL characters.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
![screen shot 2017-05-11 at 2 59 38 pm](https://cloud.githubusercontent.com/assets/10351828/25969460/8cdb64b4-365a-11e7-831d-46f94c17e1cc.png)

