### PR TITLE
Remove backgroundColor CSS attribute from ReferenceArea component

### DIFF
--- a/__tests__/components/__snapshots__/ReferenceArea.jsx.snap
+++ b/__tests__/components/__snapshots__/ReferenceArea.jsx.snap
@@ -2,7 +2,6 @@ exports[`<ReferenceArea /> matches snapshot 1`] = `
 <div
   style={
     Object {
-      "backgroundColor": "#262626",
       "bottom": 0,
       "display": "inline-flex",
       "flexFlow": "row nowrap",

--- a/src/components/ReferenceArea.jsx
+++ b/src/components/ReferenceArea.jsx
@@ -6,7 +6,6 @@ import githubIcon from '../../res/github-icon-blue.png';
 
 const style = {
   paper: {
-    backgroundColor: '#262626', // light black
     bottom: 0,
     right: 0,
     padding: '0.7rem',


### PR DESCRIPTION
## Description
This PR removes the background color attribute from the `ReferenceArea` component

## Motivation and Context
Fixes #486 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Screenshots (if appropriate):
Before:
<img width="1436" alt="screen shot 2017-05-15 at 8 37 52 am" src="https://cloud.githubusercontent.com/assets/10211603/26060778/b463627c-394b-11e7-9d09-109f2e40493f.png">


After:
<img width="1437" alt="screen shot 2017-05-15 at 8 34 14 am" src="https://cloud.githubusercontent.com/assets/10211603/26060125/b4db4366-3949-11e7-9ff2-0b1cfe7e0139.png">
