### PR TITLE
Optimize highlight.js imports

### DIFF
--- a/src/util/highlight.js
+++ b/src/util/highlight.js
@@ -1,0 +1,13 @@
+// Default hljs isn't imported as it contains ALL languages (which totals to
+// ~520 kb).
+import hljs from 'highlight.js/lib/highlight';
+
+// Each language needs to be imported like so:
+import java from 'highlight.js/lib/languages/java';
+import python from 'highlight.js/lib/languages/python';
+
+// Register each language to the hljs instance
+hljs.registerLanguage('java', java);
+hljs.registerLanguage('python', python);
+
+export default hljs;

--- a/src/util/highlight.js
+++ b/src/util/highlight.js
@@ -3,10 +3,12 @@
 import hljs from 'highlight.js/lib/highlight';
 
 // Each language needs to be imported like so:
+import go from 'highlight.js/lib/languages/go';
 import java from 'highlight.js/lib/languages/java';
 import python from 'highlight.js/lib/languages/python';
 
 // Register each language to the hljs instance
+hljs.registerLanguage('go', go);
 hljs.registerLanguage('java', java);
 hljs.registerLanguage('python', python);
 

--- a/src/util/highlight.js
+++ b/src/util/highlight.js
@@ -4,46 +4,26 @@ import hljs from 'highlight.js/lib/highlight';
 
 // Each language needs to be imported like so:
 import bash from 'highlight.js/lib/languages/bash';
-import clojure from 'highlight.js/lib/languages/clojure';
 import cs from 'highlight.js/lib/languages/cs';
-import fortran from 'highlight.js/lib/languages/fortran';
 import go from 'highlight.js/lib/languages/go';
-import haskell from 'highlight.js/lib/languages/haskell';
 import java from 'highlight.js/lib/languages/java';
 import javascript from 'highlight.js/lib/languages/javascript';
-import lisp from 'highlight.js/lib/languages/lisp';
-import lua from 'highlight.js/lib/languages/lua';
-import matlab from 'highlight.js/lib/languages/matlab';
-import perl from 'highlight.js/lib/languages/perl';
 import php from 'highlight.js/lib/languages/php';
 import python from 'highlight.js/lib/languages/python';
 import r from 'highlight.js/lib/languages/r';
 import ruby from 'highlight.js/lib/languages/ruby';
-import scala from 'highlight.js/lib/languages/scala';
-import sql from 'highlight.js/lib/languages/sql';
 import x86asm from 'highlight.js/lib/languages/x86asm';
-import xml from 'highlight.js/lib/languages/xml';
 
 // Register each language to the hljs instance
 hljs.registerLanguage('bash', bash);
-hljs.registerLanguage('clojure', clojure);
 hljs.registerLanguage('cs', cs);
-hljs.registerLanguage('fortran', fortran);
 hljs.registerLanguage('go', go);
-hljs.registerLanguage('haskell', haskell);
 hljs.registerLanguage('java', java);
 hljs.registerLanguage('javascript', javascript);
-hljs.registerLanguage('lisp', lisp);
-hljs.registerLanguage('lua', lua);
-hljs.registerLanguage('matlab', matlab);
-hljs.registerLanguage('perl', perl);
 hljs.registerLanguage('php', php);
 hljs.registerLanguage('python', python);
 hljs.registerLanguage('r', r);
 hljs.registerLanguage('ruby', ruby);
-hljs.registerLanguage('scala', scala);
-hljs.registerLanguage('sql', sql);
 hljs.registerLanguage('x86asm', x86asm);
-hljs.registerLanguage('xml', xml);
 
 export default hljs;

--- a/src/util/markdown-renderer-options.js
+++ b/src/util/markdown-renderer-options.js
@@ -1,4 +1,4 @@
-import hljs from 'highlight.js';
+import hljs from './highlight';
 
 export default {
   langPrefix: 'hljs language-',


### PR DESCRIPTION
## Description
This PR refactors our imports from `highlight.js`, eschewing the default instance (which is around 520 kb when imported) and instead using a hand-rolled solution that supports only the Java and Python languages and is 12 kb. 

## Motivation and Context
To decrease our bundle sizes, the benefits of which should be obvious.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
Before:
`Highlight.js` bundled size: (520kb)
<img width="1421" alt="screen shot 2017-05-15 at 3 44 24 pm" src="https://cloud.githubusercontent.com/assets/10211603/26078738/1a23b9ce-3986-11e7-9018-cb3e464b007b.png">

Total bundle size: (~1.5mb)
<img width="1421" alt="screen shot 2017-05-15 at 3 44 34 pm" src="https://cloud.githubusercontent.com/assets/10211603/26078769/32e0178c-3986-11e7-908b-1cb6951c816d.png">

After:
`Highlight.js` bundled size: (~12kb)
<img width="1420" alt="screen shot 2017-05-15 at 3 44 44 pm" src="https://cloud.githubusercontent.com/assets/10211603/26078803/4832a5aa-3986-11e7-87cd-769002c8e947.png">

Total bundle size: (~1mb)
<img width="1422" alt="screen shot 2017-05-15 at 3 44 54 pm" src="https://cloud.githubusercontent.com/assets/10211603/26078817/539a0e88-3986-11e7-9ac8-5ba310e8be7d.png">
