### PR TITLE
Add button to delete snippets

### DIFF
--- a/__tests__/actions/__snapshots__/app.js.snap
+++ b/__tests__/actions/__snapshots__/app.js.snap
@@ -23,6 +23,67 @@ Object {
 }
 `;
 
+exports[`Actions: App async actions deleteSnippet() dispatches the correct actions if the action fails 1`] = `
+Array [
+  Object {
+    "payload": "Deleting...",
+    "type": "ADD_NOTIFICATION",
+  },
+  Object {
+    "payload": "Failed to delete snippet; please try again",
+    "type": "ADD_NOTIFICATION",
+  },
+]
+`;
+
+exports[`Actions: App async actions deleteSnippet() dispatches the correct actions if the action succeeded 1`] = `
+Array [
+  Object {
+    "payload": "Deleting...",
+    "type": "ADD_NOTIFICATION",
+  },
+  Object {
+    "type": "CLOSE_NOTIFICATION",
+  },
+  Object {
+    "payload": "Snippet Deleted!",
+    "type": "ADD_NOTIFICATION",
+  },
+]
+`;
+
+exports[`Actions: App async actions saveExisting() dispatches SAVE_FAILED if save failed 1`] = `
+Array [
+  Object {
+    "payload": "Saving...",
+    "type": "ADD_NOTIFICATION",
+  },
+  Object {
+    "payload": "Failed to save snippet; please try again",
+    "type": "ADD_NOTIFICATION",
+  },
+]
+`;
+
+exports[`Actions: App async actions saveExisting() dispatches SAVE_SUCCEEDED if saved 1`] = `
+Array [
+  Object {
+    "payload": "Saving...",
+    "type": "ADD_NOTIFICATION",
+  },
+  Object {
+    "type": "CLOSE_NOTIFICATION",
+  },
+  Object {
+    "payload": "Codesplaination Saved!",
+    "type": "ADD_NOTIFICATION",
+  },
+  Object {
+    "type": "SAVE_SUCCEEDED",
+  },
+]
+`;
+
 exports[`Actions: App async actions saveNew() dispatches SAVE_FAILED if save failed 1`] = `
 Array [
   Object {

--- a/__tests__/actions/__snapshots__/app.js.snap
+++ b/__tests__/actions/__snapshots__/app.js.snap
@@ -33,6 +33,9 @@ Array [
     "payload": "Failed to delete snippet; please try again",
     "type": "ADD_NOTIFICATION",
   },
+  Object {
+    "type": "CLOSE_NOTIFICATION",
+  },
 ]
 `;
 

--- a/__tests__/actions/app.js
+++ b/__tests__/actions/app.js
@@ -218,41 +218,79 @@ describe('Actions: App', () => {
           });
       });
     });
+    describe('deleteSnippet()', () => {
+      it('dispatches the correct actions if the action succeeded', () => {
+        const snippetKey = 'snippetKey';
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent();
+          request.respondWith({
+            status: 200,
+          });
+        });
+        const store = mockStore({
+          user: {
+            token: '',
+            selectedOrg: '',
+          },
+        });
+        return store.dispatch(actions.deleteSnippet(snippetKey))
+          .then(() => {
+            expect(store.getActions()).toMatchSnapshot();
+          });
+      });
+      it('dispatches the correct actions if the action fails', () => {
+        const snippetKey = 'snippetKey';
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent();
+          request.respondWith({
+            status: 400,
+          });
+        });
+        const store = mockStore({
+          user: {
+            token: '',
+            selectedOrg: '',
+          },
+        });
+        return store.dispatch(actions.deleteSnippet(snippetKey))
+          .catch(() => {
+            expect(store.getActions()).toMatchSnapshot();
+          });
+      });
+    });
     describe('saveExisting()', () => {
-      it('description', () => {
-        it('dispatches SAVE_SUCCEEDED if saved', () => {
-          moxios.wait(() => {
-            const request = moxios.requests.mostRecent();
-            request.respondWith({
-              status: 200,
-              response: { status: '200' },
-            });
+      it('dispatches SAVE_SUCCEEDED if saved', () => {
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent();
+          request.respondWith({
+            status: 200,
+            response: { status: '200' },
           });
-          const store = mockStore({
-            app: {},
-            user: { token: '', username: '' },
-          });
-          return store.dispatch(actions.saveExisting())
-            .then(() => { // return of async actions
-              expect(store.getActions()).toMatchSnapshot();
-            });
         });
-        it('dispatches SAVE_FAILED if save failed', () => {
-          moxios.wait(() => {
-            const request = moxios.requests.mostRecent();
-            request.respondWith({
-              status: 400,
-            });
-          });
-          const store = mockStore({
-            app: {},
-            user: { token: '', username: '' },
-          });
-          return store.dispatch(actions.saveExisting())
-            .then(() => { // return of async actions
-              expect(store.getActions()).toMatchSnapshot();
-            });
+        const store = mockStore({
+          app: {},
+          user: { token: '', username: '' },
         });
+        return store.dispatch(actions.saveExisting())
+          .then(() => { // return of async actions
+            expect(store.getActions()).toMatchSnapshot();
+          });
+      });
+      it('dispatches SAVE_FAILED if save failed', () => {
+        moxios.wait(() => {
+          const request = moxios.requests.mostRecent();
+          request.respondWith({
+            status: 400,
+          });
+        });
+        const store = mockStore({
+          app: {},
+          user: { token: '', username: '' },
+        });
+        return store.dispatch(actions.saveExisting())
+          .then(() => { // return of async actions
+            expect(store.getActions()).toMatchSnapshot();
+          });
       });
     });
   });

--- a/__tests__/components/ConfirmationDialog.jsx
+++ b/__tests__/components/ConfirmationDialog.jsx
@@ -3,20 +3,20 @@ import { shallow } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
-import ConfirmLockDialog from '../../src/components/ConfirmLockDialog';
+import ConfirmationDialog from '../../src/components/ConfirmationDialog';
 
 const mockFunctionProps = {
   accept: jest.fn(),
   reject: jest.fn(),
 };
 
-describe('<ConfirmLockDialog />', () => {
+describe('<ConfirmationDialog />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = node => shallow(node, { context: { muiTheme } });
 
   it('matches snapshot when it is open', () => {
     const wrapper = shallowWithContext(
-      <ConfirmLockDialog
+      <ConfirmationDialog
         isOpen
         {...mockFunctionProps}
       />,
@@ -26,7 +26,7 @@ describe('<ConfirmLockDialog />', () => {
 
   it('matches snapshot when it is closed', () => {
     const wrapper = shallowWithContext(
-      <ConfirmLockDialog
+      <ConfirmationDialog
         isOpen={false}
         {...mockFunctionProps}
       />,

--- a/__tests__/components/DeleteButton.test.jsx
+++ b/__tests__/components/DeleteButton.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { shallowToJson } from 'enzyme-to-json';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+import DeleteButton from '../../src/components/buttons/DeleteButton';
+
+describe('<DeleteButton />', () => {
+  const muiTheme = getMuiTheme();
+  const shallowWithContext = node => shallow(node, { context: { muiTheme } });
+
+  it('matches snapshot of when the app is not in read-only mode', () => {
+    const wrapper = shallowWithContext(
+      <DeleteButton
+        onClick={jest.fn()}
+        isEnabled={false}
+      />,
+    );
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('matches snapshot of when the app is in read-only mode', () => {
+    const wrapper = shallowWithContext(
+      <DeleteButton
+        onClick={jest.fn()}
+        isEnabled
+      />,
+    );
+    expect(shallowToJson(wrapper)).toMatchSnapshot();
+  });
+
+  describe('prop: onClick', () => {
+    it('is triggered when clicked', () => {
+      const onClick = jest.fn();
+      const wrapper = shallowWithContext(
+        <DeleteButton
+          onClick={onClick}
+          isEnabled
+        />,
+    );
+      const button = wrapper.find('IconButton');
+      button.simulate('touchTap');
+      expect(onClick).toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/components/SnippetAreaToolbar.test.jsx
+++ b/__tests__/components/SnippetAreaToolbar.test.jsx
@@ -6,12 +6,14 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import SnippetAreaToolbar from '../../src/components/SnippetAreaToolbar';
 
 const defaultProps = {
-  canSave: true,
+  canEdit: true,
+  deleteEnabled: true,
   language: 'python',
   onLanguageChange: jest.fn(),
   onLockClick: jest.fn(),
   onSaveClick: jest.fn(),
   onSaveAsClick: jest.fn(),
+  onDeleteClick: jest.fn(),
   onTitleChange: jest.fn(),
   onOrgChanged: jest.fn(),
   readOnly: false,
@@ -119,7 +121,7 @@ describe('<SnippetAreaToolbar />', () => {
         <SnippetAreaToolbar
           {...defaultProps}
           readOnly={readOnly}
-        />
+        />,
       );
       expect(wrapper.find('LockButton').prop('readOnly')).toBe(readOnly);
     });
@@ -129,7 +131,7 @@ describe('<SnippetAreaToolbar />', () => {
         <SnippetAreaToolbar
           {...defaultProps}
           readOnly={readOnly}
-        />
+        />,
       );
       expect(wrapper.find('LanguageSelector').prop('disabled')).toBe(readOnly);
     });

--- a/__tests__/components/__snapshots__/ConfirmationDialog.jsx.snap
+++ b/__tests__/components/__snapshots__/ConfirmationDialog.jsx.snap
@@ -1,4 +1,4 @@
-exports[`<ConfirmLockDialog /> matches snapshot when it is closed 1`] = `
+exports[`<ConfirmationDialog /> matches snapshot when it is closed 1`] = `
 <Dialog
   actions={
     Array [
@@ -39,13 +39,10 @@ exports[`<ConfirmLockDialog /> matches snapshot when it is closed 1`] = `
   }
   modal={true}
   open={false}
-  repositionOnUpdate={true}
-  title="Are you sure you want to lock editing?">
-  Note that you will not be able to revert back to edit mode
-</Dialog>
+  repositionOnUpdate={true} />
 `;
 
-exports[`<ConfirmLockDialog /> matches snapshot when it is open 1`] = `
+exports[`<ConfirmationDialog /> matches snapshot when it is open 1`] = `
 <Dialog
   actions={
     Array [
@@ -86,8 +83,5 @@ exports[`<ConfirmLockDialog /> matches snapshot when it is open 1`] = `
   }
   modal={true}
   open={true}
-  repositionOnUpdate={true}
-  title="Are you sure you want to lock editing?">
-  Note that you will not be able to revert back to edit mode
-</Dialog>
+  repositionOnUpdate={true} />
 `;

--- a/__tests__/components/__snapshots__/DeleteButton.test.jsx.snap
+++ b/__tests__/components/__snapshots__/DeleteButton.test.jsx.snap
@@ -1,0 +1,91 @@
+exports[`<DeleteButton /> matches snapshot of when the app is in read-only mode 1`] = `
+<span
+  style={
+    Object {
+      "height": "48px",
+    }
+  }>
+  <div
+    data-for="trash-tip"
+    data-tip={true}
+    styles={
+      Object {
+        "display": "inline-block",
+      }
+    }>
+    <IconButton
+      disableTouchRipple={false}
+      disabled={false}
+      iconStyle={Object {}}
+      id="TrashButton"
+      onTouchTap={[Function]}
+      style={
+        Object {
+          "zIndex": 5,
+        }
+      }
+      tooltipPosition="bottom-center"
+      touch={false}>
+      <ActionDelete />
+    </IconButton>
+  </div>
+  <ReactTooltip
+    effect="solid"
+    id="trash-tip"
+    insecure={true}
+    place="bottom"
+    resizeHide={true}
+    wrapper="div">
+    <span>
+      Click to delete snippet
+    </span>
+  </ReactTooltip>
+</span>
+`;
+
+exports[`<DeleteButton /> matches snapshot of when the app is not in read-only mode 1`] = `
+<span
+  style={
+    Object {
+      "height": "48px",
+    }
+  }>
+  <div
+    data-for="trash-tip"
+    data-tip={true}
+    styles={
+      Object {
+        "display": "inline-block",
+      }
+    }>
+    <IconButton
+      disableTouchRipple={false}
+      disabled={true}
+      iconStyle={Object {}}
+      id="TrashButton"
+      onTouchTap={[Function]}
+      style={
+        Object {
+          "zIndex": 5,
+        }
+      }
+      tooltipPosition="bottom-center"
+      touch={false}>
+      <ActionDelete />
+    </IconButton>
+  </div>
+  <ReactTooltip
+    effect="solid"
+    id="trash-tip"
+    insecure={true}
+    place="bottom"
+    resizeHide={true}
+    wrapper="div">
+    <span>
+      You can only delete snippets
+      <br />
+      that you own
+    </span>
+  </ReactTooltip>
+</span>
+`;

--- a/__tests__/components/__snapshots__/SnippetAreaToolbar.test.jsx.snap
+++ b/__tests__/components/__snapshots__/SnippetAreaToolbar.test.jsx.snap
@@ -70,7 +70,12 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is no
           "flex": "1 1 auto",
         }
       } />
-    <div>
+    <div
+      style={
+        Object {
+          "display": "inline-flex",
+        }
+      }>
       <LockButton
         onClick={[Function]}
         readOnly={false}
@@ -92,6 +97,14 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is no
           ]
         }
         selectedOrg="galactic-federation"
+        style={
+          Object {
+            "flex": "1 1 auto",
+          }
+        } />
+      <DeleteButton
+        isEnabled={true}
+        onClick={[Function]}
         style={
           Object {
             "flex": "1 1 auto",
@@ -174,7 +187,12 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is re
           "flex": "1 1 auto",
         }
       } />
-    <div>
+    <div
+      style={
+        Object {
+          "display": "inline-flex",
+        }
+      }>
       <LockButton
         onClick={[Function]}
         readOnly={true}
@@ -196,6 +214,14 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is re
           ]
         }
         selectedOrg="galactic-federation"
+        style={
+          Object {
+            "flex": "1 1 auto",
+          }
+        } />
+      <DeleteButton
+        isEnabled={true}
+        onClick={[Function]}
         style={
           Object {
             "flex": "1 1 auto",

--- a/__tests__/containers/SnippetArea.test.jsx
+++ b/__tests__/containers/SnippetArea.test.jsx
@@ -34,6 +34,7 @@ describe('<SnippetArea />', () => {
   });
   const wrapper = shallow(
     <SnippetArea
+      snippetKey="foo_bar"
       dispatch={mockDispatch}
       annotations={mockAnnotations}
       snippet={mockSnippet}

--- a/__tests__/util/__snapshots__/requests.test.js.snap
+++ b/__tests__/util/__snapshots__/requests.test.js.snap
@@ -1,0 +1,11 @@
+exports[`util: requests stripState returns an object with correct keys for a serialized state 1`] = `
+Object {
+  "AST": Object {},
+  "annotations": Object {},
+  "filters": Object {},
+  "readOnly": false,
+  "snippet": "",
+  "snippetLanguage": "python3",
+  "snippetTitle": "",
+}
+`;

--- a/__tests__/util/__snapshots__/requests.test.js.snap
+++ b/__tests__/util/__snapshots__/requests.test.js.snap
@@ -1,4 +1,4 @@
-exports[`util: requests stripState returns an object with correct keys for a serialized state 1`] = `
+exports[`util: requests normalizeState returns an object with correct keys for a serialized state 1`] = `
 Object {
   "AST": Object {},
   "annotations": Object {},

--- a/__tests__/util/requests.test.js
+++ b/__tests__/util/requests.test.js
@@ -50,7 +50,7 @@ describe('util: requests', () => {
     });
   });
 
-  describe('stripState', () => {
+  describe('normalizeState', () => {
     it('returns an object with correct keys for a serialized state', () => {
       const state = {
         foobar: 'blah',
@@ -64,7 +64,7 @@ describe('util: requests', () => {
         snippetKey: '',
         snippetTitle: '',
       };
-      expect(reqUtils.stripState(state)).toMatchSnapshot();
+      expect(reqUtils.normalizeState(state)).toMatchSnapshot();
     });
   });
 });

--- a/__tests__/util/requests.test.js
+++ b/__tests__/util/requests.test.js
@@ -49,4 +49,22 @@ describe('util: requests', () => {
       expect(reqUtils.sanitizeSnippetList(snippetList)).toEqual(expected);
     });
   });
+
+  describe('stripState', () => {
+    it('returns an object with correct keys for a serialized state', () => {
+      const state = {
+        foobar: 'blah',
+        annotations: {},
+        AST: {},
+        filters: {},
+        hasUnsavedChanges: false,
+        snippetLanguage: 'python3',
+        readOnly: false,
+        snippet: '',
+        snippetKey: '',
+        snippetTitle: '',
+      };
+      expect(reqUtils.stripState(state)).toMatchSnapshot();
+    });
+  });
 });

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -171,6 +171,37 @@ export const saveExisting = () => (dispatch, getState) => {
       });
 };
 
+export const deleteSnippet = snippetKey => (dispatch, getState) => {
+  // Get items out of app state
+  const {
+    user: {
+      token,
+      selectedOrg,
+    },
+  } = getState();
+
+  // Construct request objects
+  const reqHeaders = {
+    headers: {
+      Authorization: token,
+    },
+  };
+
+  // Delete the snippet
+  dispatch(addNotification('Deleting...'));
+  return axios.delete(makeSaveEndpointUrl(selectedOrg, snippetKey), reqHeaders)
+    .then(() => {
+      // Remove the 'deleting...' notifications
+      dispatch(closeNotification());
+      // Give user feedback that snippet deleted
+      dispatch(addNotification('Snippet Deleted!'));
+    })
+    .catch((err) => {
+      dispatch(addNotification('Failed to delete snippet; please try again'));
+      throw err;
+    });
+};
+
 export const loadSnippet = (username, snippetKey) => (dispatch, getState) => {
   const { token } = getState().user;
   const reqHeaders = {

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
-
+import { removeDeprecatedFiltersFromState } from '../util/codemirror-utils';
 import { addNotification, closeNotification } from './notifications';
 import { makeSaveEndpointUrl, stripState } from '../util/requests';
+import { setDefaults } from '../util/state-management';
 
 export const RESET_STATE = 'RESET_STATE';
 export const EDIT_ANNOTATION = 'EDIT_ANNOTATION';
@@ -198,6 +199,8 @@ export const deleteSnippet = snippetKey => (dispatch, getState) => {
     })
     .catch((err) => {
       dispatch(addNotification('Failed to delete snippet; please try again'));
+      // Remove error notification
+      dispatch(closeNotification());
       throw err;
     });
 };
@@ -214,7 +217,7 @@ export const loadSnippet = (username, snippetKey) => (dispatch, getState) => {
     transformResponse: [
       (data) => {
         const dataObj = JSON.parse(data);
-        return stripState(dataObj);
+        return setDefaults(removeDeprecatedFiltersFromState(stripState(dataObj)));
       },
     ],
   });

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 import { addNotification, closeNotification } from './notifications';
-import { makeSaveEndpointUrl } from '../util/requests';
+import { makeSaveEndpointUrl, stripState } from '../util/requests';
 
 export const RESET_STATE = 'RESET_STATE';
 export const EDIT_ANNOTATION = 'EDIT_ANNOTATION';
@@ -103,14 +103,19 @@ export const saveNew = org => (dispatch, getState) => {
   } = getState();
   // Construct the necessary request objects
   const reqBody = JSON.stringify(appState);
-  const reqHeaders = {
-    headers: {
-      Authorization: token,
-    },
+  const headers = {
+    Authorization: token,
   };
+  const transformRequest = [
+    (data) => {
+      const dataObj = JSON.parse(data);
+      return JSON.stringify(stripState(dataObj));
+    },
+  ];
+  const config = { headers, transformRequest };
   dispatch(addNotification('Saving...'));
     // Save the new snippet
-  return axios.post(makeSaveEndpointUrl(org), reqBody, reqHeaders)
+  return axios.post(makeSaveEndpointUrl(org), reqBody, config)
       .then((res) => {
         // Remove the 'saving...' notification
         dispatch(closeNotification());
@@ -140,14 +145,19 @@ export const saveExisting = () => (dispatch, getState) => {
 
     // Construct the necessary request objects
   const reqBody = JSON.stringify(appState);
-  const reqHeaders = {
-    headers: {
-      Authorization: token,
-    },
+  const headers = {
+    Authorization: token,
   };
+  const transformRequest = [
+    (data) => {
+      const dataObj = JSON.parse(data);
+      return JSON.stringify(stripState(dataObj));
+    },
+  ];
+  const config = { headers, transformRequest };
   dispatch(addNotification('Saving...'));
     // Update the snippet
-  return axios.put(makeSaveEndpointUrl(selectedOrg, key), reqBody, reqHeaders)
+  return axios.put(makeSaveEndpointUrl(selectedOrg, key), reqBody, config)
       .then(() => {
         // Remove the 'saving...' notification
         dispatch(closeNotification());

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -107,7 +107,9 @@ export const saveNew = org => (dispatch, getState) => {
   const headers = {
     Authorization: token,
   };
-  // `transformRequest` allows changes to the request data before it is sent to the server 
+  // This function is run by axios prior to sending POST request.
+  // It transforms data that is sent in the request by removing extra
+  // fields from the state object.
   const transformRequest = [
     (data) => {
       const dataObj = JSON.parse(data);

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -107,6 +107,7 @@ export const saveNew = org => (dispatch, getState) => {
   const headers = {
     Authorization: token,
   };
+  // `transformRequest` allows changes to the request data before it is sent to the server 
   const transformRequest = [
     (data) => {
       const dataObj = JSON.parse(data);

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { removeDeprecatedFiltersFromState } from '../util/codemirror-utils';
 import { addNotification, closeNotification } from './notifications';
-import { makeSaveEndpointUrl, stripState } from '../util/requests';
+import { makeSaveEndpointUrl, normalizeState } from '../util/requests';
 import { setDefaults } from '../util/state-management';
 
 export const RESET_STATE = 'RESET_STATE';
@@ -110,7 +110,7 @@ export const saveNew = org => (dispatch, getState) => {
   const transformRequest = [
     (data) => {
       const dataObj = JSON.parse(data);
-      return JSON.stringify(stripState(dataObj));
+      return JSON.stringify(normalizeState(dataObj));
     },
   ];
   const config = { headers, transformRequest };
@@ -152,7 +152,7 @@ export const saveExisting = () => (dispatch, getState) => {
   const transformRequest = [
     (data) => {
       const dataObj = JSON.parse(data);
-      return JSON.stringify(stripState(dataObj));
+      return JSON.stringify(normalizeState(dataObj));
     },
   ];
   const config = { headers, transformRequest };
@@ -217,7 +217,7 @@ export const loadSnippet = (username, snippetKey) => (dispatch, getState) => {
     transformResponse: [
       (data) => {
         const dataObj = JSON.parse(data);
-        return setDefaults(removeDeprecatedFiltersFromState(stripState(dataObj)));
+        return setDefaults(removeDeprecatedFiltersFromState(normalizeState(dataObj)));
       },
     ],
   });

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -211,5 +211,11 @@ export const loadSnippet = (username, snippetKey) => (dispatch, getState) => {
     method: 'GET',
     url: makeSaveEndpointUrl(username, snippetKey),
     headers: reqHeaders,
+    transformResponse: [
+      (data) => {
+        const dataObj = JSON.parse(data);
+        return stripState(dataObj);
+      },
+    ],
   });
 };

--- a/src/components/ConfirmationDialog.jsx
+++ b/src/components/ConfirmationDialog.jsx
@@ -7,7 +7,7 @@ const contentStyle = {
   width: '40%',
 };
 
-const ConfirmLockDialog = ({ accept, isOpen, reject }) => {
+const ConfirmationDialog = ({ accept, isOpen, reject, title, message }) => {
   const actionButtons = [
     <FlatButton
       label="No"
@@ -26,17 +26,17 @@ const ConfirmLockDialog = ({ accept, isOpen, reject }) => {
       modal
       open={isOpen}
       contentStyle={contentStyle}
-      title="Are you sure you want to lock editing?"
+      title={title}
     >
-      Note that you will not be able to revert back to edit mode
+      {message}
     </Dialog>
   );
 };
 
-ConfirmLockDialog.propTypes = {
+ConfirmationDialog.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   accept: PropTypes.func.isRequired,
   reject: PropTypes.func.isRequired,
 };
 
-export default ConfirmLockDialog;
+export default ConfirmationDialog;

--- a/src/components/SnippetAreaToolbar.jsx
+++ b/src/components/SnippetAreaToolbar.jsx
@@ -7,6 +7,7 @@ import ReactTooltip from 'react-tooltip';
 
 import LanguageSelector from './LanguageSelector';
 import LockButton from './buttons/LockButton';
+import DeleteButton from './buttons/DeleteButton';
 import SaveMenu from './menus/SaveMenu';
 import CustomPropTypes from '../util/custom-prop-types';
 
@@ -19,7 +20,10 @@ const styles = {
     margin: '0',
     padding: '0',
   },
-  buttons: {
+  buttonsContainer: {
+    display: 'inline-flex',
+  },
+  button: {
     flex: '1 1 auto',
   },
   toolbarField: {
@@ -45,15 +49,17 @@ here, because it does not reflow correctly when the screen is resized.
 */
 const SnippetAreaToolbar = (props) => {
   const {
-    canSave,
+    canEdit,
     language,
     onLanguageChange,
     onLockClick,
     onSaveAsClick,
     onSaveClick,
+    onDeleteClick,
     onTitleChange,
     onOrgChanged,
     readOnly,
+    deleteEnabled,
     saveEnabled,
     title,
     orgs,
@@ -99,22 +105,27 @@ const SnippetAreaToolbar = (props) => {
           onChange={onLanguageChange}
           style={styles.toolbarField}
         />
-        <div>
+        <div style={styles.buttonsContainer}>
           <LockButton
             onClick={onLockClick}
             readOnly={readOnly}
-            style={styles.buttons}
+            style={styles.button}
           />
           <SaveMenu
-            canSave={canSave}
+            canSave={canEdit}
             enabled={saveEnabled}
             id="saveMenu"
             onSaveAsClick={onSaveAsClick}
             onSaveClick={onSaveClick}
-            style={styles.buttons}
+            style={styles.button}
             orgs={orgs}
             onOrgChanged={onOrgChanged}
             selectedOrg={selectedOrg}
+          />
+          <DeleteButton
+            style={styles.button}
+            isEnabled={deleteEnabled}
+            onClick={onDeleteClick}
           />
         </div>
       </div>
@@ -123,12 +134,14 @@ const SnippetAreaToolbar = (props) => {
 };
 
 SnippetAreaToolbar.propTypes = {
-  canSave: PropTypes.bool.isRequired,
+  deleteEnabled: PropTypes.bool.isRequired,
+  canEdit: PropTypes.bool.isRequired,
   language: PropTypes.string.isRequired,
   onLanguageChange: PropTypes.func.isRequired,
   onLockClick: PropTypes.func.isRequired,
   onSaveAsClick: PropTypes.func.isRequired,
   onSaveClick: PropTypes.func.isRequired,
+  onDeleteClick: PropTypes.func.isRequired,
   onTitleChange: PropTypes.func.isRequired,
   onOrgChanged: PropTypes.func.isRequired,
   readOnly: PropTypes.bool.isRequired,

--- a/src/components/buttons/DeleteButton.jsx
+++ b/src/components/buttons/DeleteButton.jsx
@@ -1,0 +1,63 @@
+import React, { PropTypes } from 'react';
+
+import IconButton from 'material-ui/IconButton';
+import TrashCan from 'material-ui/svg-icons/action/delete';
+import ReactTooltip from 'react-tooltip';
+
+const styles = {
+  button: {
+    zIndex: 5,
+  },
+  buttonContainer: {
+    height: '48px',
+  },
+  inlineBlock: {
+    display: 'inline-block',
+  },
+};
+
+const toolTipText = isEnabled => (
+  isEnabled ?
+    (<span>
+      Click to delete snippet
+    </span>)
+    :
+    (<span>
+      You can only delete snippets
+      <br />
+      that you own
+    </span>)
+);
+
+const DeleteButton = ({ onClick, isEnabled }) => (
+  <span style={styles.buttonContainer}>
+    <div
+      styles={styles.inlineBlock}
+      data-tip
+      data-for="trash-tip"
+    >
+      <IconButton
+        id="TrashButton"
+        disabled={!isEnabled}
+        onTouchTap={onClick}
+        style={styles.button}
+      >
+        <TrashCan />
+      </IconButton>
+    </div>
+    <ReactTooltip
+      id="trash-tip"
+      effect="solid"
+      place="bottom"
+    >
+      {toolTipText(isEnabled)}
+    </ReactTooltip>
+  </span>
+);
+
+DeleteButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  isEnabled: PropTypes.bool.isRequired,
+};
+
+export default DeleteButton;

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -9,6 +9,7 @@ import SnippetArea from './SnippetArea';
 import {
   loadSnippet,
   restoreState,
+  setSnippetKey,
 } from '../actions/app';
 import { setPermissions, setAuthor } from '../actions/permissions';
 import { switchOrg } from '../actions/user';
@@ -96,13 +97,10 @@ export class AppBody extends Component {
       .then((res) => {
         // Normalize the app state received from S3
         const appState = setDefaults(removeDeprecatedFiltersFromState(res.data));
-        // Snippet may not have a S3 key value saved; set it to the URL's id
-        // param if the state object is lacking it
-        if (!appState.snippetKey) {
-          appState.snippetKey = snippetKey;
-        }
+
         // Restore the application's state
         dispatch(restoreState(appState));
+        dispatch(setSnippetKey(snippetKey));
         this.updatePermissions();
 
         // Reroute if using legacy url

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -14,10 +14,8 @@ import {
 import { setPermissions, setAuthor } from '../actions/permissions';
 import { switchOrg } from '../actions/user';
 import NotFound from '../components/NotFound';
-import { removeDeprecatedFiltersFromState } from '../util/codemirror-utils';
 import CustomPropTypes from '../util/custom-prop-types';
 import { sanitizeKey } from '../util/requests';
-import { setDefaults } from '../util/state-management';
 
 const styles = {
   body: {
@@ -94,10 +92,7 @@ export class AppBody extends Component {
     }
 
     dispatch(loadSnippet(snippetOwner, snippetKey))
-      .then((res) => {
-        // Normalize the app state received from S3
-        const appState = setDefaults(removeDeprecatedFiltersFromState(res.data));
-
+      .then(({ data: appState }) => {
         // Restore the application's state
         dispatch(restoreState(appState));
         dispatch(setSnippetKey(snippetKey));

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -29,7 +29,7 @@ import {
   updateUserSnippets,
   switchOrg,
 } from '../actions/user';
-import ConfirmLockDialog from '../components/ConfirmLockDialog';
+import ConfirmationDialog from '../components/ConfirmationDialog';
 import Editor from '../components/Editor';
 import SnippetAreaToolbar from '../components/SnippetAreaToolbar';
 import CustomPropTypes from '../util/custom-prop-types';
@@ -66,6 +66,7 @@ export class SnippetArea extends React.Component {
     super(props);
     this.state = {
       lockDialogOpen: false,
+      deleteDialogOpen: false,
       avatarUrl: '',
     };
 
@@ -80,6 +81,7 @@ export class SnippetArea extends React.Component {
     this.handleToggleReadOnly = this.handleToggleReadOnly.bind(this);
     this.handleOrgChanged = this.handleOrgChanged.bind(this);
     this.handleDelete = this.handleDelete.bind(this);
+    this.showDeleteModal = this.showDeleteModal.bind(this);
   }
 
   componentDidMount() {
@@ -139,9 +141,14 @@ export class SnippetArea extends React.Component {
     this.handleCloseModal();
   }
 
+  showDeleteModal() {
+    this.setState({ deleteDialogOpen: true });
+  }
+
   handleCloseModal() {
     this.setState({
       lockDialogOpen: false,
+      deleteDialogOpen: false,
     });
   }
 
@@ -212,6 +219,7 @@ export class SnippetArea extends React.Component {
   }
 
   handleDelete() {
+    this.setState({ deleteDialogOpen: false });
     const { dispatch, snippetKey, router } = this.props;
     dispatch(deleteSnippet(snippetKey))
       .then(() => {
@@ -266,7 +274,7 @@ export class SnippetArea extends React.Component {
           <SnippetAreaToolbar
             canEdit={canEdit}
             language={snippetLanguage}
-            onDeleteClick={this.handleDelete}
+            onDeleteClick={this.showDeleteModal}
             deleteEnabled={deleteEnabled}
             onLanguageChange={this.handleLanguageChanged}
             onLockClick={this.handleLock}
@@ -282,10 +290,19 @@ export class SnippetArea extends React.Component {
             avatarUrl={avatarUrl}
             author={author}
           />
-          <ConfirmLockDialog
+          <ConfirmationDialog
             accept={this.handleToggleReadOnly}
             isOpen={this.state.lockDialogOpen}
             reject={this.handleCloseModal}
+            title="Are you sure you want to lock editing?"
+            message="Note that you will not be able to revert back to edit mode"
+          />
+          <ConfirmationDialog
+            accept={this.handleDelete}
+            isOpen={this.state.deleteDialogOpen}
+            reject={this.handleCloseModal}
+            title="Are you sure you want to delete this snippet?"
+            message="Note that you can not undo this action"
           />
           <Editor
             AST={AST}

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -24,7 +24,11 @@ import {
 import { addNotification } from '../actions/notifications';
 import { loadParser } from '../actions/parser';
 import { setPermissions } from '../actions/permissions';
-import { updateUserSnippets, switchOrg } from '../actions/user';
+import {
+  fetchSnippetLists,
+  updateUserSnippets,
+  switchOrg,
+} from '../actions/user';
 import ConfirmLockDialog from '../components/ConfirmLockDialog';
 import Editor from '../components/Editor';
 import SnippetAreaToolbar from '../components/SnippetAreaToolbar';
@@ -213,6 +217,7 @@ export class SnippetArea extends React.Component {
       .then(() => {
         dispatch(resetState());
         dispatch(updateUserSnippets());
+        dispatch(fetchSnippetLists()); // Update org snippet lists
         router.push('/'); // TODO: Test that does not redirect delete fails
       });
   }

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -16,6 +16,7 @@ import {
   saveExisting,
   setSnippetContents,
   setSnippetKey,
+  setAuthor,
   setSnippetLanguage,
   setSnippetTitle,
   toggleEditState,
@@ -224,6 +225,7 @@ export class SnippetArea extends React.Component {
     dispatch(deleteSnippet(snippetKey))
       .then(() => {
         dispatch(resetState());
+        dispatch(setAuthor(''));
         dispatch(updateUserSnippets());
         dispatch(fetchSnippetLists()); // Update org snippet lists
         router.push('/'); // TODO: Test that does not redirect delete fails

--- a/src/util/requests.js
+++ b/src/util/requests.js
@@ -54,3 +54,28 @@ export const fetchUserAvatar = (user, token) => {
   const reqUrl = makeUserUrl(user);
   return axios.get(reqUrl, reqHeaders).then(({ data }) => data.avatar_url);
 };
+
+/*
+Returns new object containing only the fields from the given state object
+that we want to serialize.
+*/
+export const stripState = (state) => {
+  const {
+    annotations,
+    AST,
+    filters,
+    snippetLanguage,
+    readOnly,
+    snippetTitle,
+    snippet,
+  } = state;
+  return {
+    annotations,
+    AST,
+    filters,
+    snippetLanguage,
+    readOnly,
+    snippetTitle,
+    snippet,
+  };
+};

--- a/src/util/requests.js
+++ b/src/util/requests.js
@@ -59,7 +59,7 @@ export const fetchUserAvatar = (user, token) => {
 Returns new object containing only the fields from the given state object
 that we want to serialize.
 */
-export const stripState = (state) => {
+export const normalizeState = (state) => {
   const {
     annotations,
     AST,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
User can now delete snippets they own. Also, users can delete snippets from organizations they are members of.
Note: User cannot delete snippets if they are not logged in or do not own the snippet.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #413 branches off of #497, so that must be merged first.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
### Enabled when logged in
![screen shot 2017-05-15 at 15 48 56](https://cloud.githubusercontent.com/assets/25034502/26078985/dc906e44-3986-11e7-8c1c-ce0dcf1ee67a.png)

### Shows confirmation Modal
![screen shot 2017-05-15 at 15 49 01](https://cloud.githubusercontent.com/assets/25034502/26078986/dc939664-3986-11e7-8477-91fbd6ea5c4f.png)

### Shows snackbar when deleting
![screen shot 2017-05-15 at 15 49 13](https://cloud.githubusercontent.com/assets/25034502/26078987/dc94f112-3986-11e7-9098-ce41af5a5989.png)

### Shows snackbar when deleted
![screen shot 2017-05-15 at 15 49 14](https://cloud.githubusercontent.com/assets/25034502/26078989/dc9728a6-3986-11e7-8be4-6bd44dd8ce48.png)

### Delete is enabled for organization members
![screen shot 2017-05-15 at 15 49 55](https://cloud.githubusercontent.com/assets/25034502/26078988/dc9670fa-3986-11e7-93dc-4ac505f285c5.png)

### Not enabled on unsaved snippets
![screen shot 2017-05-15 at 15 48 41](https://cloud.githubusercontent.com/assets/25034502/26078995/e1e1cbea-3986-11e7-976f-9e5ab1b8d512.png)