### PR TITLE
Fix errors and warnings in console

### DIFF
--- a/__tests__/components/__snapshots__/DeleteButton.test.jsx.snap
+++ b/__tests__/components/__snapshots__/DeleteButton.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`<DeleteButton /> matches snapshot of when the app is in read-only mode 
   <div
     data-for="trash-tip"
     data-tip={true}
-    styles={
+    style={
       Object {
         "display": "inline-block",
       }
@@ -53,7 +53,7 @@ exports[`<DeleteButton /> matches snapshot of when the app is not in read-only m
   <div
     data-for="trash-tip"
     data-tip={true}
-    styles={
+    style={
       Object {
         "display": "inline-block",
       }

--- a/src/components/buttons/DeleteButton.jsx
+++ b/src/components/buttons/DeleteButton.jsx
@@ -32,7 +32,7 @@ const toolTipText = isEnabled => (
 const DeleteButton = ({ onClick, isEnabled }) => (
   <span style={styles.buttonContainer}>
     <div
-      styles={styles.inlineBlock}
+      style={styles.inlineBlock}
       data-tip
       data-for="trash-tip"
     >

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -9,7 +9,6 @@ import SnippetArea from './SnippetArea';
 import {
   loadSnippet,
   restoreState,
-  setSnippetKey,
 } from '../actions/app';
 import { setPermissions, setAuthor } from '../actions/permissions';
 import { switchOrg } from '../actions/user';
@@ -74,7 +73,6 @@ export class AppBody extends Component {
 
     this.setState({ pathname });
     if (!snippetOwner && !snippetKey) {
-      // This is a new snippet for the current user, enable all permissions
       const permissions = {
         canRead: true,
         canEdit: true,
@@ -92,10 +90,12 @@ export class AppBody extends Component {
     }
 
     dispatch(loadSnippet(snippetOwner, snippetKey))
-      .then(({ data: appState }) => {
+      .then(({ data }) => {
+        // Add snippetKey to the state before restoring
+        const appState = { ...data, snippetKey };
+
         // Restore the application's state
-        dispatch(restoreState(appState));
-        dispatch(setSnippetKey(snippetKey));
+        dispatch(restoreState({ ...appState }));
         this.updatePermissions();
 
         // Reroute if using legacy url

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -15,7 +15,6 @@ import {
   resetState,
   saveExisting,
   saveNew,
-  setAuthor,
   setSnippetContents,
   setSnippetKey,
   setSnippetLanguage,
@@ -24,7 +23,7 @@ import {
 } from '../actions/app';
 import { addNotification } from '../actions/notifications';
 import { loadParser } from '../actions/parser';
-import { setPermissions } from '../actions/permissions';
+import { setPermissions, setAuthor } from '../actions/permissions';
 import {
   fetchSnippetLists,
   switchOrg,
@@ -113,8 +112,7 @@ export class SnippetArea extends React.Component {
         });
         return;
       }
-      fetchUserAvatar(nextProps.author, token)
-        .then((avatarUrl) => { this.setState({ avatarUrl }); });
+      fetchUserAvatar(token).then(avatarUrl => this.setState({ avatarUrl }));
     }
   }
 

--- a/src/util/requests.js
+++ b/src/util/requests.js
@@ -43,15 +43,15 @@ export const sanitizeSnippetList = (snippetList) => {
   return snippetList;
 };
 
-export const makeUserUrl = user => `${GITHUB_API_URL}/users/${user}`;
+export const makeUserUrl = () => `${GITHUB_API_URL}/user`;
 
-export const fetchUserAvatar = (user, token) => {
+export const fetchUserAvatar = (token) => {
   const reqHeaders = {
     headers: {
       Authorization: `token ${token}`,
     },
   };
-  const reqUrl = makeUserUrl(user);
+  const reqUrl = makeUserUrl();
   return axios.get(reqUrl, reqHeaders).then(({ data }) => data.avatar_url);
 };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Fixed import location of `setAuthor` in `SnippetArea`, so the user is properly redirected and their snippet lists are updated when they delete a snippet.
* Fixed the URL being used to get a user's avatar, which was resulting in a 404.
* Fixed PropType warning due to the app being rendered before `snippetKey` was set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #507. Nobody likes type errors, 404s, and PropType warnings.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Mobile:
- [ ] Other:
