### PR TITLE
Clean the application state when loading a snippet from SnippetList

### DIFF
--- a/__tests__/components/OrgSelector.test.jsx
+++ b/__tests__/components/OrgSelector.test.jsx
@@ -7,16 +7,16 @@ import OrgSelector from '../../src/components/OrgSelector';
 
 const defaultProps = {
   onChange: jest.fn(),
-  orgs: ["galactic-federation", "international-counsel-of-ricks"]
-}
+  orgs: ['galactic-federation', 'international-counsel-of-ricks'],
+};
 
 describe('<OrgSelector />', () => {
   const muiTheme = getMuiTheme();
-  const shallowWithContext = (node) => shallow(node, { context: { muiTheme } });
+  const shallowWithContext = node => shallow(node, { context: { muiTheme } });
 
   it('matches snapshot', () => {
     const wrapper = shallowWithContext(
-      <OrgSelector {...defaultProps}/>
+      <OrgSelector {...defaultProps} />,
     );
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });

--- a/__tests__/containers/CodesplainAppBar.test.jsx
+++ b/__tests__/containers/CodesplainAppBar.test.jsx
@@ -1,21 +1,47 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import cookie from 'react-cookie';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { shallowToJson } from 'enzyme-to-json';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import injectTapEventPlugin from 'react-tap-event-plugin';
 
-import { CodesplainAppBar } from '../../src/containers/CodesplainAppBar';
+import generateMockStore from '../../src/testUtils/mockStore';
+import generateMockRouter from '../../src/testUtils/mockRouter';
+import {
+  ConnectedAppBar,
+  CodesplainAppBar,
+} from '../../src/containers/CodesplainAppBar';
+
+// Needed for onTouchTap
+// http://stackoverflow.com/a/34015469/988941
+injectTapEventPlugin();
 
 const mockAuthor = 'phoenixperson';
+const defaultStore = {
+  app: { hasUnsavedChanges: true },
+  user: {
+    avatarUrl: '',
+    orgSnippets: {},
+    token: '',
+    username: '',
+    userSnippets: {},
+  },
+};
 
 describe('<CodesplainAppBar />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = node => shallow(node, { context: { muiTheme } });
+  const mountWithContext = node => mount(node, {
+    context: { muiTheme },
+    childContextTypes: { muiTheme: React.PropTypes.object },
+  });
 
   describe('snapshot tests', () => {
     afterEach(() => {
       cookie.remove('token');
     });
+
     it('user is not logged in', () => {
       const wrapper = shallowWithContext(
         <CodesplainAppBar
@@ -36,6 +62,65 @@ describe('<CodesplainAppBar />', () => {
         />,
       );
       expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+  });
+
+  describe('resetApplication', () => {
+    it('dispatches the correct actions to reset state', () => {
+      const store = generateMockStore(defaultStore);
+      const wrapper = mountWithContext(
+        <Provider store={store}>
+          <ConnectedAppBar />
+        </Provider>,
+      );
+      const codesplainAppBar = wrapper.find(CodesplainAppBar).getNode();
+      codesplainAppBar.resetApplication();
+      expect(store.getActions()).toMatchSnapshot();
+    });
+  });
+
+  describe('handleSnippetSelected', () => {
+    it('routes to the next snippet', () => {
+      const store = generateMockStore(defaultStore);
+      const router = generateMockRouter();
+      const wrapper = mountWithContext(
+        <Provider store={store}>
+          <ConnectedAppBar router={router} />
+        </Provider>,
+      );
+      const codesplainAppBar = wrapper.find(CodesplainAppBar).getNode();
+      const snippetOwner = 'username';
+      const snippetKey = 'snippet';
+      codesplainAppBar.handleSnippetSelected(snippetOwner, snippetKey);
+      expect(router.push).toBeCalledWith(`/${snippetOwner}/${snippetKey}`);
+    });
+  });
+
+  describe('redirectToHomePage', () => {
+    it('does not redirect to the home URL if already there', () => {
+      const store = generateMockStore(defaultStore);
+      const router = generateMockRouter();
+      const wrapper = mountWithContext(
+        <Provider store={store}>
+          <ConnectedAppBar router={router} />
+        </Provider>,
+      );
+      const codesplainAppBar = wrapper.find(CodesplainAppBar).getNode();
+      codesplainAppBar.redirectToHomePage();
+      expect(router.push).not.toBeCalled();
+    });
+
+    it('redirects to home URL if not already there', () => {
+      const store = generateMockStore(defaultStore);
+      const router = generateMockRouter({ location: { pathname: '/foobar' } });
+      const wrapper = mountWithContext(
+        <Provider store={store}>
+          <ConnectedAppBar router={router} />
+        </Provider>,
+      );
+      const codesplainAppBar = wrapper.find(CodesplainAppBar).getNode();
+      codesplainAppBar.redirectToHomePage();
+      expect(router.push).toBeCalledWith('/');
     });
   });
 });

--- a/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
+++ b/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
@@ -1,3 +1,18 @@
+exports[`<CodesplainAppBar /> resetApplication dispatches the correct actions to reset state 1`] = `
+Array [
+  Object {
+    "type": "RESET_STATE",
+  },
+  Object {
+    "payload": "",
+    "type": "SET_AUTHOR",
+  },
+  Object {
+    "type": "CLOSE_ANNOTATION_PANEL",
+  },
+]
+`;
+
 exports[`<CodesplainAppBar /> snapshot tests user is logged in 1`] = `
 <div>
   <AppBar

--- a/src/containers/Annotations.jsx
+++ b/src/containers/Annotations.jsx
@@ -4,8 +4,8 @@ import { Card, CardHeader, CardText } from 'material-ui/Card';
 import { withRouter } from 'react-router';
 
 import {
-  openAnnotationPanel,
   closeAnnotationPanel,
+  openAnnotationPanel,
 } from '../actions/annotation';
 import {
   saveAnnotation,
@@ -39,10 +39,10 @@ export class Annotations extends React.Component {
       hasPreceedingAnnotation: false,
       hasProceedingAnnotation: false,
     };
+    this.getNextAnnotation = this.getNextAnnotation.bind(this);
+    this.getPreviousAnnotation = this.getPreviousAnnotation.bind(this);
     this.handleCloseAnnotation = this.handleCloseAnnotation.bind(this);
     this.handleSaveAnnotation = this.handleSaveAnnotation.bind(this);
-    this.getPreviousAnnotation = this.getPreviousAnnotation.bind(this);
-    this.getNextAnnotation = this.getNextAnnotation.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -134,8 +134,8 @@ export class Annotations extends React.Component {
     } = this.props;
 
     const {
-      hasProceedingAnnotation,
       hasPreceedingAnnotation,
+      hasProceedingAnnotation,
     } = this.state;
 
     if (!isDisplayingAnnotation) {
@@ -158,20 +158,20 @@ export class Annotations extends React.Component {
             <div>
               <h2 style={styles.headerItem}>Annotation</h2>
               <AnnotationPaginator
-                style={styles.headerItem}
                 getNextAnnotation={this.getNextAnnotation}
                 getPreviousAnnotation={this.getPreviousAnnotation}
-                hasPrevAnnotation={hasPreceedingAnnotation}
                 hasNextAnnotation={hasProceedingAnnotation}
+                hasPrevAnnotation={hasPreceedingAnnotation}
+                style={styles.headerItem}
               />
             </div>
           }
         />
         <AnnotationPanel
           annotation={annotation}
+          closeAnnotation={this.handleCloseAnnotation}
           lineAnnotated={lineAnnotated}
           saveAnnotation={this.handleSaveAnnotation}
-          closeAnnotation={this.handleCloseAnnotation}
         />
       </Card>
     );
@@ -182,9 +182,13 @@ Annotations.propTypes = {
   annotation: PropTypes.string.isRequired,
   annotations: CustomPropTypes.annotations.isRequired,
   isDisplayingAnnotation: PropTypes.bool.isRequired,
-  readOnly: PropTypes.bool.isRequired,
   lineAnnotated: CustomPropTypes.lineAnnotated.isRequired,
-  snippetKey: PropTypes.string.isRequired,
+  readOnly: PropTypes.bool.isRequired,
+  snippetKey: PropTypes.string,
+};
+
+Annotations.defaultProps = {
+  snippetKey: '',
 };
 
 const mapStateToProps = (state) => {

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -96,6 +96,7 @@ export class AppBody extends Component {
         // Restore the application's state
         dispatch(restoreState(appState));
         dispatch(setSnippetKey(snippetKey));
+        dispatch(setAuthor(snippetOwner));
         this.updatePermissions();
 
         // Reroute if using legacy url
@@ -104,7 +105,6 @@ export class AppBody extends Component {
         if (pathname !== nextRoute) {
           router.push(nextRoute);
         }
-        dispatch(setAuthor(snippetOwner));
       }, () => {
         // Failed to get the snippet, either bad URL or unauthorized
         this.setState({

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -63,6 +63,7 @@ export class CodesplainAppBar extends Component {
     this.handleTitleTouchTap = this.handleTitleTouchTap.bind(this);
     this.onLoginClick = this.onLoginClick.bind(this);
     this.redirectToHomePage = this.redirectToHomePage.bind(this);
+    this.resetApplication = this.resetApplication.bind(this);
   }
 
   componentDidMount() {
@@ -123,6 +124,10 @@ export class CodesplainAppBar extends Component {
     window.location = GITHUB_URL;
   }
 
+  handleDialogClose() {
+    this.setState({ isDialogOpen: false });
+  }
+
   handleSignOut() {
     const { router } = this.props;
     cookie.remove('token', { path: '/' });
@@ -133,6 +138,7 @@ export class CodesplainAppBar extends Component {
 
   handleSnippetSelected(snippetOwner, snippetKey) {
     const { router } = this.props;
+    this.resetApplication();
     router.push(`/${snippetOwner}/${snippetKey}`);
   }
 
@@ -147,32 +153,30 @@ export class CodesplainAppBar extends Component {
     }
   }
 
-  redirectToHomePage() {
-    const {
-      dispatch,
-      router,
-    } = this.props;
+  handleConfirmNavigation() {
+    // Close the dialog
+    this.handleDialogClose();
+    // Redirect the user to the home page
+    this.redirectToHomePage();
+  }
+
+  resetApplication() {
+    const { dispatch } = this.props;
 
     // Reset state
     dispatch(resetState());
     dispatch(setAuthor(''));
     // Close the annotation panel
     dispatch(closeAnnotationPanel());
+  }
+
+  redirectToHomePage() {
+    const { router } = this.props;
+    this.resetApplication();
     // If the user is not already at the home page, redirect them to it
     if (router.location.pathname !== '/') {
       router.push('/');
     }
-  }
-
-  handleDialogClose() {
-    this.setState({ isDialogOpen: false });
-  }
-
-  handleConfirmNavigation() {
-    // Close the dialog
-    this.handleDialogClose();
-    // Redirect the user to the home page
-    this.redirectToHomePage();
   }
 
   render() {

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -277,5 +277,5 @@ const mapStateToProps = (state) => {
     avatarUrl,
   };
 };
-
-export default withRouter(connect(mapStateToProps)(CodesplainAppBar));
+export const ConnectedAppBar = connect(mapStateToProps)(CodesplainAppBar);
+export default withRouter(ConnectedAppBar);

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -6,7 +6,6 @@ import {
 } from 'material-ui';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import cookie from 'react-cookie';
 
 import { openAnnotationPanel } from '../actions/annotation';
 import {

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -351,7 +351,7 @@ SnippetArea.propTypes = {
   readOnly: PropTypes.bool.isRequired,
   selectedOrg: PropTypes.string,
   snippet: PropTypes.string.isRequired,
-  snippetKey: PropTypes.string.isRequired,
+  snippetKey: PropTypes.string,
   snippetLanguage: PropTypes.string.isRequired,
   snippetTitle: PropTypes.string.isRequired,
   username: PropTypes.string,
@@ -363,6 +363,7 @@ SnippetArea.defaultProps = {
   errors: [],
   openLine: -1,
   selectedOrg: '',
+  snippetKey: '',
   username: '',
 };
 

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -97,11 +97,12 @@ export class SnippetArea extends React.Component {
       author,
       avatarUrl: loggedInUserAvatarUrl,
       username: loggedInUser,
+      token,
     } = this.props;
-    const token = cookie.load('token');
 
     if (!nextProps.author || !token) {
       this.setState({ avatarUrl: '' });
+      return;
     }
     if (author !== nextProps.author) {
       // The URL to the user's avatar is already in the store, so if the snippet
@@ -354,6 +355,7 @@ SnippetArea.propTypes = {
   snippetKey: PropTypes.string,
   snippetLanguage: PropTypes.string.isRequired,
   snippetTitle: PropTypes.string.isRequired,
+  token: PropTypes.string,
   username: PropTypes.string,
 };
 
@@ -364,6 +366,7 @@ SnippetArea.defaultProps = {
   openLine: -1,
   selectedOrg: '',
   snippetKey: '',
+  token: '',
   username: '',
 };
 
@@ -394,6 +397,7 @@ const mapStateToProps = (state) => {
       avatarUrl,
       orgs,
       selectedOrg,
+      token,
       username,
     },
   } = state;
@@ -413,6 +417,7 @@ const mapStateToProps = (state) => {
     snippetKey,
     snippetLanguage,
     snippetTitle,
+    token,
     username,
   };
 };

--- a/src/testUtils/mockRouter.js
+++ b/src/testUtils/mockRouter.js
@@ -1,0 +1,20 @@
+const router = {
+  push: jest.fn(),
+  location: {
+    pathname: '/',
+  },
+};
+
+export const resetMockRouter = (routerObject) => {
+  routerObject.push.mockClear();
+};
+
+export const generateMockRouter = (props) => {
+  resetMockRouter(router);
+  return {
+    ...router,
+    ...props,
+  };
+};
+
+export default generateMockRouter;

--- a/src/testUtils/mockStore.js
+++ b/src/testUtils/mockStore.js
@@ -1,0 +1,11 @@
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+// Default middlewares used in the application
+const defaultMiddlewares = [thunk];
+// Function to generate a mock store object
+const generateMockStore = configureStore(defaultMiddlewares);
+
+// Export a wrapper around generateMockStore to allow for a default store
+// object.
+export default (store = {}) => generateMockStore(store);


### PR DESCRIPTION
## Description
Refactors `<CodesplainAppBar />` to dispatch actions to clean the application state when a snippet is selected from the `<SnippetMenu />`
Also adds test utilities to mock the Redux store and React-Router.

## Motivation and Context
Fixes #505 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other: