### PR TITLE
Parser is invoked when gist loaded

### DIFF
--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -27,6 +27,7 @@ import {
   resetState,
   setSnippetContents,
   setSnippetTitle,
+  parseSnippet,
  } from '../actions/app';
 import { closeAnnotationPanel } from '../actions/annotation';
 import { setAuthor } from '../actions/permissions';
@@ -189,7 +190,10 @@ export class CodesplainAppBar extends Component {
   handleImportGist(name, url) {
     const { dispatch } = this.props;
     dispatch(setSnippetTitle(name));
-    fetchGist(url).then(contents => dispatch(setSnippetContents(contents)));
+    fetchGist(url).then((contents) => {
+      dispatch(setSnippetContents(contents));
+      dispatch(parseSnippet(contents));
+    });
     this.redirectToHomePage();
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When a gist is loaded, the parser is invoked

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #511 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
