### PR TITLE
Logout users with invalid tokens

### DIFF
--- a/__tests__/containers/CodesplainAppBar.test.jsx
+++ b/__tests__/containers/CodesplainAppBar.test.jsx
@@ -6,6 +6,7 @@ import { shallowToJson } from 'enzyme-to-json';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 
+import { saveAccessToken } from '../../src/actions/user';
 import generateMockStore from '../../src/testUtils/mockStore';
 import generateMockRouter from '../../src/testUtils/mockRouter';
 import {
@@ -62,6 +63,48 @@ describe('<CodesplainAppBar />', () => {
         />,
       );
       expect(shallowToJson(wrapper)).toMatchSnapshot();
+    });
+  });
+
+  describe('fetchUserAccountInfo', () => {
+    it('saves the access token if it has not been already', () => {
+      const accessToken = 'token';
+      cookie.save('token', accessToken, { path: '/' });
+      const store = generateMockStore({
+        ...defaultStore,
+        user: {
+          ...defaultStore.user,
+          // Set the username so the user info requests aren't triggered
+          username: 'Rick Sanchez',
+        },
+      });
+      const router = generateMockRouter({ location: { pathname: '/foobar' } });
+      mountWithContext(
+        <Provider store={store}>
+          <ConnectedAppBar router={router} />
+        </Provider>,
+      );
+      expect(store.getActions()[0]).toEqual(saveAccessToken(accessToken));
+      cookie.remove('token', { path: '/' });
+    });
+
+    it('does not save the access token if it already has been', () => {
+      const store = generateMockStore({
+        ...defaultStore,
+        user: {
+          ...defaultStore.user,
+          token: 'token',
+          // Set the username so the user info requests aren't triggered
+          username: 'Rick Sanchez',
+        },
+      });
+      const router = generateMockRouter({ location: { pathname: '/foobar' } });
+      mountWithContext(
+        <Provider store={store}>
+          <ConnectedAppBar router={router} />
+        </Provider>,
+      );
+      expect(store.getActions().length).toEqual(0);
     });
   });
 

--- a/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
+++ b/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
@@ -8,6 +8,9 @@ Array [
     "type": "SET_AUTHOR",
   },
   Object {
+    "type": "CLEAR_USER_CREDENTIALS",
+  },
+  Object {
     "type": "CLOSE_ANNOTATION_PANEL",
   },
 ]
@@ -17,21 +20,10 @@ exports[`<CodesplainAppBar /> snapshot tests user is logged in 1`] = `
 <div>
   <AppBar
     iconElementRight={
-      <AppMenu
-        avatarUrl=""
-        gists={Array []}
-        onImportGist={[Function]}
-        onSignOut={[Function]}
-        onSnippetSelected={[Function]}
-        orgSnippets={Object {}}
-        userSnippets={Object {}}
-        username="FooBar" />
+      <LoginButton
+        onClick={[Function]} />
     }
-    iconStyleRight={
-      Object {
-        "marginTop": "16px",
-      }
-    }
+    iconStyleRight={Object {}}
     showMenuIconButton={false}
     style={
       Object {

--- a/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
+++ b/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
@@ -8,9 +8,6 @@ Array [
     "type": "SET_AUTHOR",
   },
   Object {
-    "type": "CLEAR_USER_CREDENTIALS",
-  },
-  Object {
     "type": "CLOSE_ANNOTATION_PANEL",
   },
 ]

--- a/__tests__/reducers/__snapshots__/user.js.snap
+++ b/__tests__/reducers/__snapshots__/user.js.snap
@@ -3,7 +3,7 @@ Object {
   "avatarUrl": "",
   "orgSnippets": Object {},
   "orgs": Array [],
-  "selectedOrg": null,
+  "selectedOrg": undefined,
   "token": "",
   "userSnippets": Object {},
   "username": "",

--- a/src/actions/gists.js
+++ b/src/actions/gists.js
@@ -1,6 +1,29 @@
+import {
+  parseSnippet,
+  setSnippetContents,
+} from './app';
+import {
+  fetchGist as makeFetchGistRequest,
+  fetchGists as makeFetchGistsRequest,
+} from '../util/requests';
+
 export const SET_GISTS = 'SET_GISTS';
 
 export const setGists = gists => ({
   type: SET_GISTS,
   payload: gists,
 });
+
+export const fetchGist = url => dispatch => (
+  makeFetchGistRequest(url)
+    .then((contents) => {
+      dispatch(setSnippetContents(contents));
+      dispatch(parseSnippet(contents));
+    })
+);
+
+export const fetchGists = () => (dispatch, getState) => {
+  const { token } = getState().user;
+  return makeFetchGistsRequest(token)
+    .then((gists) => { dispatch(setGists(gists)); });
+};

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -129,7 +129,16 @@ export const fetchUserInfo = () => (dispatch, getState) => {
     method: 'GET',
     url: 'https://api.github.com/user',
     headers: reqHeaders,
-  });
+  })
+    .then(({ data }) => {
+      const { login: username, avatar_url: userAvatarURL } = data;
+      dispatch(saveUsername(username));
+      dispatch(setAvatarUrl(userAvatarURL));
+
+      // Add user's username to orgs list, and select it as default
+      dispatch(addOrg(username));
+      dispatch(switchOrg(username));
+    });
 };
 
 export const fetchUserOrgs = () => (dispatch, getState) => {
@@ -142,5 +151,12 @@ export const fetchUserOrgs = () => (dispatch, getState) => {
     method: 'GET',
     url: 'https://api.github.com/user/orgs',
     headers: reqHeaders,
+  })
+  .then(({ data }) => {
+    // Dispatch orgs to state
+    // Create a list of the names organizations the user belongs to
+    const orgs = data.map(org => org.login);
+    // Save the organizations list to the store
+    dispatch(addOrganizations(orgs));
   });
 };

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -20,7 +20,6 @@ import {
 import { addNotification } from '../actions/notifications';
 import { setAuthor } from '../actions/permissions';
 import {
-  clearUserCredentials,
   fetchSnippetLists,
   fetchUserInfo,
   fetchUserOrgs,
@@ -172,7 +171,6 @@ export class CodesplainAppBar extends Component {
     // Reset state
     dispatch(resetState());
     dispatch(setAuthor(''));
-    dispatch(clearUserCredentials());
     // Close the annotation panel
     dispatch(closeAnnotationPanel());
   }

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -8,29 +8,24 @@ import {
 import { withRouter } from 'react-router';
 import cookie from 'react-cookie';
 
-
-import { setGists } from '../actions/gists';
-import { fetchGists, fetchGist } from '../util/requests';
-
+import { closeAnnotationPanel } from '../actions/annotation';
 import {
-  addOrg,
-  addOrganizations,
+  resetState,
+  setSnippetTitle,
+ } from '../actions/app';
+import {
+  fetchGist,
+  fetchGists,
+} from '../actions/gists';
+import { addNotification } from '../actions/notifications';
+import { setAuthor } from '../actions/permissions';
+import {
+  clearUserCredentials,
   fetchSnippetLists,
   fetchUserInfo,
   fetchUserOrgs,
   saveAccessToken,
-  saveUsername,
-  setAvatarUrl,
-  switchOrg,
 } from '../actions/user';
-import {
-  resetState,
-  setSnippetContents,
-  setSnippetTitle,
-  parseSnippet,
- } from '../actions/app';
-import { closeAnnotationPanel } from '../actions/annotation';
-import { setAuthor } from '../actions/permissions';
 import LoginButton from '../components/buttons/LoginButton';
 import AppMenu from '../components/menus/AppMenu';
 import CustomPropTypes from '../util/custom-prop-types';
@@ -46,8 +41,8 @@ const styles = {
     marginTop: '16px',
   },
   title: {
-    cursor: 'pointer',
     color: '#00e6e6', // tealish
+    cursor: 'pointer',
     fontWeight: 'bold',
   },
 };
@@ -62,18 +57,18 @@ export class CodesplainAppBar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      isLoggedIn: cookie.load('token') !== undefined,
+      isLoggedIn: false,
       isDialogOpen: false,
     };
     this.handleConfirmNavigation = this.handleConfirmNavigation.bind(this);
     this.handleDialogClose = this.handleDialogClose.bind(this);
+    this.handleImportGist = this.handleImportGist.bind(this);
     this.handleSignOut = this.handleSignOut.bind(this);
     this.handleSnippetSelected = this.handleSnippetSelected.bind(this);
     this.handleTitleTouchTap = this.handleTitleTouchTap.bind(this);
     this.onLoginClick = this.onLoginClick.bind(this);
     this.redirectToHomePage = this.redirectToHomePage.bind(this);
     this.resetApplication = this.resetApplication.bind(this);
-    this.handleImportGist = this.handleImportGist.bind(this);
   }
 
   componentDidMount() {
@@ -87,32 +82,22 @@ export class CodesplainAppBar extends Component {
 
     // If we have a token (thus are logged in), get user's info & save to state
     if (tokenCookie) {
-      dispatch(fetchUserOrgs())
-        .then(({ data }) => {
-          // Dispatch orgs to state
-          // Create a list of the names organizations the user belongs to
-          const orgs = data.map(org => org.login);
-          // Save the organizations list to the store
-          dispatch(addOrganizations(orgs));
-          return dispatch(fetchUserInfo());
-        })
-        .then(({ data }) => {
-          const { login: username, avatar_url: userAvatarURL } = data;
-          dispatch(saveUsername(username));
-          dispatch(setAvatarUrl(userAvatarURL));
-
-          // Add user's username to orgs list, and select it as default
-          dispatch(addOrg(username));
-          dispatch(switchOrg(username));
-          fetchGists(tokenCookie)
-            .then(gists => dispatch(setGists(gists)));
-          return dispatch(fetchSnippetLists());
-        })
-        .catch(() => {
+      dispatch(fetchUserInfo())
+        .then(() => { this.setState({ isLoggedIn: true }); })
+        .then(() => dispatch(fetchUserOrgs()))
+        .then(() => dispatch(fetchSnippetLists()))
+        .then(() => dispatch(fetchGists()))
+        .catch((err) => {
           // If we fail, token must have been invalid:
           // remove it and redirect to home page
-          cookie.remove('token', { path: '/' });
-          router.push('/');
+          if (err.response.status === 401) {
+            this.resetApplication();
+            this.setState({ isLoggedIn: false });
+            cookie.remove('token', { path: '/' });
+            router.push('/');
+          } else {
+            dispatch(addNotification('Error fetching user information'));
+          }
         });
     }
   }
@@ -142,6 +127,7 @@ export class CodesplainAppBar extends Component {
 
   handleSignOut() {
     const { router } = this.props;
+    this.resetApplication();
     cookie.remove('token', { path: '/' });
     this.setState({ isLoggedIn: false });
     router.push('/');
@@ -175,11 +161,8 @@ export class CodesplainAppBar extends Component {
   handleImportGist(name, url) {
     const { dispatch } = this.props;
     dispatch(setSnippetTitle(name));
-    fetchGist(url).then((contents) => {
-      dispatch(setSnippetContents(contents));
-      dispatch(parseSnippet(contents));
-    });
-    this.redirectToHomePage();
+    dispatch(fetchGist(url))
+      .then(() => { this.redirectToHomePage(); });
   }
 
   resetApplication() {
@@ -188,6 +171,7 @@ export class CodesplainAppBar extends Component {
     // Reset state
     dispatch(resetState());
     dispatch(setAuthor(''));
+    dispatch(clearUserCredentials());
     // Close the annotation panel
     dispatch(closeAnnotationPanel());
   }
@@ -205,13 +189,13 @@ export class CodesplainAppBar extends Component {
     const actions = [
       <FlatButton
         label="Cancel"
-        secondary
         onTouchTap={this.handleDialogClose}
+        secondary
       />,
       <FlatButton
         label="Discard"
-        primary
         onTouchTap={this.handleConfirmNavigation}
+        primary
       />,
     ];
 
@@ -220,13 +204,13 @@ export class CodesplainAppBar extends Component {
     const rightElement = isLoggedIn ?
       (<AppMenu
         avatarUrl={avatarUrl}
+        gists={gists}
+        onImportGist={this.handleImportGist}
         onSignOut={this.handleSignOut}
         onSnippetSelected={this.handleSnippetSelected}
         orgSnippets={orgSnippets}
         username={username}
         userSnippets={userSnippets}
-        gists={gists}
-        onImportGist={this.handleImportGist}
       />)
       : <LoginButton onClick={this.onLoginClick} />;
     const titleElement = (
@@ -241,11 +225,11 @@ export class CodesplainAppBar extends Component {
     return (
       <div>
         <AppBar
-          style={styles.appBar}
-          showMenuIconButton={false}
-          title={titleElement}
           iconElementRight={rightElement}
           iconStyleRight={isLoggedIn ? styles.rightElement : {}}
+          showMenuIconButton={false}
+          style={styles.appBar}
+          title={titleElement}
         />
         <Dialog
           actions={actions}
@@ -262,21 +246,21 @@ export class CodesplainAppBar extends Component {
 
 CodesplainAppBar.propTypes = {
   avatarUrl: PropTypes.string,
+  gists: CustomPropTypes.gists,
   hasUnsavedChanges: PropTypes.bool.isRequired,
   orgSnippets: CustomPropTypes.orgSnippets,
   token: PropTypes.string,
   username: PropTypes.string,
   userSnippets: CustomPropTypes.snippets,
-  gists: CustomPropTypes.gists,
 };
 
 CodesplainAppBar.defaultProps = {
   avatarUrl: '',
+  gists: [],
   orgSnippets: {},
   token: '',
   username: '',
   userSnippets: {},
-  gists: [],
 };
 
 const mapStateToProps = (state) => {
@@ -305,5 +289,7 @@ const mapStateToProps = (state) => {
     gists,
   };
 };
+
 export const ConnectedAppBar = connect(mapStateToProps)(CodesplainAppBar);
+
 export default withRouter(ConnectedAppBar);

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -7,7 +7,7 @@ import * as actions from '../actions/user';
 export const initialState = {
   avatarUrl: '',
   orgs: [],
-  selectedOrg: null,
+  selectedOrg: undefined,
   token: '',
   username: '',
   userSnippets: {},
@@ -38,8 +38,6 @@ const user = (state = initialState, action) => {
   case actions.CLEAR_USER_CREDENTIALS: {
     return {
       ...initialState,
-      orgs: state.orgs,
-      selectedOrg: state.selectedOrg,
     };
   }
   case actions.SAVE_ACCESS_TOKEN: {

--- a/src/util/requests.js
+++ b/src/util/requests.js
@@ -61,17 +61,17 @@ export const fetchUserAvatar = (user, token) => {
 // Each gist contains a dict of filenames to file info. We need to iterate and get
 // the filenames and urls
 export const gistReducer = (list, gist) => {
-  forIn(gist.files, ({ raw_url: url }, name) =>
-    list.push({ name, url }));
+  forIn(gist.files, ({ raw_url: url }, name) => list.push({ name, url }));
   return list;
 };
 
 export const fetchGists = token =>
-  axios.get(GIST_URL, githubHeaders(token)).then(({ data }) =>
-    data.reduce(gistReducer, []));
+  axios.get(GIST_URL, githubHeaders(token))
+    .then(({ data }) => data.reduce(gistReducer, []));
 
 export const fetchGist = url =>
-  axios.get(url).then(({ data }) => data);
+  axios.get(url)
+    .then(({ data }) => data);
 /*
 Returns new object containing only the fields from the given state object
 that we want to serialize.


### PR DESCRIPTION
## Description
- When a user attempts to access their information with an invalid Github token, the application will clear their credentials and reset the application. This will occur early in the application life cycle, specifically in `<CodesplainAppBar />`'s `componentDidMount` method.
- Abstracts much of the promise logic away from the component, and instead lets the thunks handle them.

- This PR relies on [this PR](https://github.com/maryvilledev/codesplain-lambdas/pull/117) being merged in order to work correctly

## Motivation and Context
Fix #465 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
