### PR TITLE
Fix line overlap at non-100% zoom

### DIFF
--- a/src/styles/codesplain.css
+++ b/src/styles/codesplain.css
@@ -20,9 +20,10 @@ body {
 }
 
 .cm-s-codesplain span {
-  font-size: 108%;
-  line-height: 108%;
-  padding-top: 0.3%;
+  font-size: 105%;
+  line-height: 130%;
+  padding-top: 2px;
+  padding-bottom: 2px;
 }
 
 .ReactCodeMirror {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fiddled around with the CodeMirror CSS until it looked good at different zoom levels.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #521. The current CodeMirror CSS doesn't always work if the zoom level is not at 100% in all browsers.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (in Chrome browser):
### 65% zoom
![screen shot 2017-05-22 at 9 05 05 am](https://cloud.githubusercontent.com/assets/10351828/26312743/2ee121c4-3ece-11e7-95f9-44507c2fdddf.png)

### 100% zoom
![screen shot 2017-05-22 at 9 05 22 am](https://cloud.githubusercontent.com/assets/10351828/26312745/2ee39eea-3ece-11e7-9fcd-a2f9986883bb.png)

### 120% zoom
![screen shot 2017-05-22 at 9 05 31 am](https://cloud.githubusercontent.com/assets/10351828/26312744/2ee19e06-3ece-11e7-8d91-a0fe78b28eee.png)
