### PR TITLE
Fix responsiveness of the RuleLabel buttons

### DIFF
--- a/__tests__/components/__snapshots__/RuleLabel.test.jsx.snap
+++ b/__tests__/components/__snapshots__/RuleLabel.test.jsx.snap
@@ -1,22 +1,11 @@
 exports[`<RuleLabel /> snapshot tests matches snapshot of when it is active 1`] = `
 <div
+  className="rule-label"
   onClick={[Function]}
   style={
     Object {
       "backgroundColor": "#FF0000",
       "borderColor": "transparent",
-      "borderRadius": "5px",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "cursor": "pointer",
-      "display": "inline-block",
-      "fontSize": "10pt",
-      "lineHeight": 1,
-      "marginRight": "5px",
-      "marginTop": "5px",
-      "maxWidth": "200px",
-      "padding": "5px",
-      "width": "100%",
     }
   }>
   Example Rule
@@ -35,23 +24,12 @@ exports[`<RuleLabel /> snapshot tests matches snapshot of when it is active 1`] 
 
 exports[`<RuleLabel /> snapshot tests matches snapshot of when it is not active 1`] = `
 <div
+  className="rule-label"
   onClick={[Function]}
   style={
     Object {
       "backgroundColor": "transparent",
       "borderColor": "#e6e6e6",
-      "borderRadius": "5px",
-      "borderStyle": "solid",
-      "borderWidth": "1px",
-      "cursor": "pointer",
-      "display": "inline-block",
-      "fontSize": "10pt",
-      "lineHeight": 1,
-      "marginRight": "5px",
-      "marginTop": "5px",
-      "maxWidth": "200px",
-      "padding": "5px",
-      "width": "100%",
     }
   }>
   Example Rule

--- a/__tests__/components/__snapshots__/RulesSelector.test.jsx.snap
+++ b/__tests__/components/__snapshots__/RulesSelector.test.jsx.snap
@@ -1,5 +1,6 @@
 exports[`<RulesSelector /> matches snapshot 1`] = `
-<div>
+<div
+  className="rule-selector-container">
   <RuleLabel
     count={1}
     isActive={false}

--- a/src/components/RuleLabel.jsx
+++ b/src/components/RuleLabel.jsx
@@ -28,7 +28,8 @@ const RuleLabel = ({ color, rule, count, onClick, isActive }) => {
 
   return (
     <div
-      style={{ ...styles.label, backgroundColor, borderColor }}
+      className="rule-label"
+      style={{ backgroundColor, borderColor }}
       onClick={onClick}
     >
       {rule}

--- a/src/components/RulesSelector.jsx
+++ b/src/components/RulesSelector.jsx
@@ -29,7 +29,7 @@ const makeListItems = (filters, onRuleSelected) => (
 const RulesSelector = ({ filters, onRuleSelected }) => {
   const listItems = makeListItems(filters, onRuleSelected);
   return (
-    <div>
+    <div className="rule-selector-container">
       {listItems}
     </div>
   );

--- a/src/components/RulesSelector.jsx
+++ b/src/components/RulesSelector.jsx
@@ -1,5 +1,7 @@
 import React, { PropTypes } from 'react';
+
 import RuleLabel from './RuleLabel';
+import CustomPropTypes from '../util/custom-prop-types';
 
 const makeListItems = (filters, onRuleSelected) => (
   Object.keys(filters)
@@ -34,12 +36,7 @@ const RulesSelector = ({ filters, onRuleSelected }) => {
 };
 
 RulesSelector.propTypes = {
-  filters: PropTypes.shape({
-    color: PropTypes.string,
-    count: PropTypes.number,
-    prettyTokenName: PropTypes.string,
-    selected: PropTypes.bool,
-  }).isRequired,
+  filters: CustomPropTypes.filters.isRequired,
   onRuleSelected: PropTypes.func.isRequired,
 };
 

--- a/src/containers/Annotations.jsx
+++ b/src/containers/Annotations.jsx
@@ -149,7 +149,7 @@ export class Annotations extends React.Component {
       return (
         <Card style={styles.card}>
           <CardTitle
-            title={<h2>Annotation</h2>}
+            title={<h2 className="section-title">Annotation</h2>}
           />
           <CardText>{prompt}</CardText>
         </Card>
@@ -160,7 +160,12 @@ export class Annotations extends React.Component {
         <CardTitle
           title={
             <div>
-              <h2 style={styles.headerItem}>Annotation</h2>
+              <h2
+                className="section-title"
+                style={styles.headerItem}
+              >
+                Annotation
+              </h2>
               <AnnotationPaginator
                 getNextAnnotation={this.getNextAnnotation}
                 getPreviousAnnotation={this.getPreviousAnnotation}

--- a/src/containers/AppBody.jsx
+++ b/src/containers/AppBody.jsx
@@ -151,7 +151,7 @@ export class AppBody extends Component {
     return (
       <div style={styles.body} id="app-body" >
         <SnippetArea />
-        <div id="app-body-right-section" style={styles.rightSection}>
+        <div id="app-body-right-section">
           <FilterArea />
           <Annotations />
         </div>

--- a/src/containers/FilterArea.jsx
+++ b/src/containers/FilterArea.jsx
@@ -83,7 +83,7 @@ export class FilterArea extends React.Component {
       >
         <CardTitle
           actAsExpander={doesHaveFilters}
-          title={<h2>Filters</h2>}
+          title={<h2 className="section-title">Filters</h2>}
           showExpandableButton={doesHaveFilters}
         />
         <CardText

--- a/src/styles/codesplain.css
+++ b/src/styles/codesplain.css
@@ -10,6 +10,31 @@ body {
   height: inherit;
 }
 
+.rule-label {
+  box-sizing: border-box;
+  border-radius: 5px;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 1 auto;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  font-size: 10pt;
+  line-height: 1;
+  max-width: 300px;
+  min-width: 130px;
+  padding: 5px;
+  width: 50%;
+}
+
+.rule-selector-container {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-start;
+  box-sizing: border-box;
+}
+
 #root {
   height: inherit;
 }
@@ -24,6 +49,10 @@ body {
   line-height: 130%;
   padding-top: 2px;
   padding-bottom: 2px;
+}
+
+.section-title {
+  margin-bottom: 0;
 }
 
 .ReactCodeMirror {


### PR DESCRIPTION
## Description
Refactors the RuleLabel buttons to use flex-box properties, making them more responsive
Also removes the padding from the Filter and Annotation titles, so there's more room for the content in their respective sections

## Motivation and Context
Fixes #517

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
