### PR TITLE
Vertically center line numbers

### DIFF
--- a/src/styles/codesplain.css
+++ b/src/styles/codesplain.css
@@ -23,7 +23,11 @@ body {
   font-size: 105%;
   line-height: 130%;
   padding-top: 2px;
-  padding-bottom: 2px;
+  padding-bottom: 3px;
+}
+
+.CodeMirror-linenumber {
+  padding-top: 3px;
 }
 
 .ReactCodeMirror {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add `padding-top` to line numbers such that they are vertically centered with the corresponding line's content.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #527.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
### Before
![screen shot 2017-05-23 at 8 37 41 am](https://cloud.githubusercontent.com/assets/10351828/26357138/f8527a4c-3f93-11e7-8be2-c295dfabef7f.png)

### After
![screen shot 2017-05-23 at 8 35 54 am](https://cloud.githubusercontent.com/assets/10351828/26357124/eec71e06-3f93-11e7-82f6-e98ded3b528e.png)
