### PR TITLE
[CodesplainAppBar] Fix bug with selected org not being reset

### DIFF
--- a/__tests__/containers/CodesplainAppBar.test.jsx
+++ b/__tests__/containers/CodesplainAppBar.test.jsx
@@ -110,7 +110,13 @@ describe('<CodesplainAppBar />', () => {
 
   describe('resetApplication', () => {
     it('dispatches the correct actions to reset state', () => {
-      const store = generateMockStore(defaultStore);
+      const store = generateMockStore({
+        ...defaultStore,
+        user: {
+          ...defaultStore.user,
+          username: 'username',
+        },
+      });
       const wrapper = mountWithContext(
         <Provider store={store}>
           <ConnectedAppBar />

--- a/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
+++ b/__tests__/containers/__snapshots__/CodesplainAppBar.test.jsx.snap
@@ -8,6 +8,10 @@ Array [
     "type": "SET_AUTHOR",
   },
   Object {
+    "payload": "username",
+    "type": "SWITCH_ORG",
+  },
+  Object {
     "type": "CLOSE_ANNOTATION_PANEL",
   },
 ]

--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -24,6 +24,7 @@ import {
   fetchUserInfo,
   fetchUserOrgs,
   saveAccessToken,
+  switchOrg,
 } from '../actions/user';
 import LoginButton from '../components/buttons/LoginButton';
 import AppMenu from '../components/menus/AppMenu';
@@ -172,11 +173,13 @@ export class CodesplainAppBar extends Component {
   }
 
   resetApplication() {
-    const { dispatch } = this.props;
+    const { dispatch, username } = this.props;
 
     // Reset state
     dispatch(resetState());
     dispatch(setAuthor(''));
+    // Reset the selected "organization" to the user's account
+    dispatch(switchOrg(username));
     // Close the annotation panel
     dispatch(closeAnnotationPanel());
   }


### PR DESCRIPTION
## Description
Fixes issue with the `selectedOrg` not being reset to the user when creating a new snippet by dispatching an action to switch the `selectedOrg` value to the user's account

## Motivation and Context
Fixes #529

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other: