### PR TITLE
Codesplain will now balk when asked to load the same snippet

### DIFF
--- a/src/containers/CodesplainAppBar.jsx
+++ b/src/containers/CodesplainAppBar.jsx
@@ -167,9 +167,11 @@ export class CodesplainAppBar extends Component {
   }
 
   handleSnippetSelected(snippetOwner, snippetKey) {
-    const { router } = this.props;
-    this.resetApplication();
-    router.push(`/${snippetOwner}/${snippetKey}`);
+    const { router, snippetKey: curr } = this.props;
+    if (snippetKey !== curr) {
+      this.resetApplication();
+      router.push(`/${snippetOwner}/${snippetKey}`);
+    }
   }
 
   handleTitleTouchTap() {
@@ -307,6 +309,7 @@ CodesplainAppBar.propTypes = {
   token: PropTypes.string,
   username: PropTypes.string,
   userSnippets: CustomPropTypes.snippets,
+  snippetKey: PropTypes.string,
 };
 
 CodesplainAppBar.defaultProps = {
@@ -316,6 +319,7 @@ CodesplainAppBar.defaultProps = {
   token: '',
   username: '',
   userSnippets: {},
+  snippetKey: '',
 };
 
 const mapStateToProps = (state) => {
@@ -323,6 +327,7 @@ const mapStateToProps = (state) => {
     app,
     app: {
       hasUnsavedChanges,
+      snippetKey,
     },
     user: {
       avatarUrl,
@@ -342,6 +347,7 @@ const mapStateToProps = (state) => {
     token,
     username,
     userSnippets,
+    snippetKey,
   };
 };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When asked to load a snippet that is already loaded, Codesplain will now skip reloading the snippet.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #533 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
