### PR TITLE
Add option to change Codemirror styles

### DIFF
--- a/__tests__/components/Editor.test.jsx
+++ b/__tests__/components/Editor.test.jsx
@@ -52,4 +52,18 @@ describe('<Editor />', () => {
       expect(wrapper.find('CodeMirror').prop('value')).toEqual(snippetContents);
     });
   });
+
+  describe('prop: codeMirrorTheme', () => {
+    it('forwarded to the CodeMirror instance', () => {
+      const codeMirrorTheme = 'monokai';
+      const wrapper = shallowWithContext(
+        <Editor
+          {...defaultProps}
+          codeMirrorTheme={codeMirrorTheme}
+        />,
+      );
+      const codeMirrorOptions = wrapper.find('CodeMirror').prop('options');
+      expect(codeMirrorOptions.theme).toEqual(codeMirrorTheme);
+    });
+  });
 });

--- a/__tests__/components/SnippetAreaToolbar.test.jsx
+++ b/__tests__/components/SnippetAreaToolbar.test.jsx
@@ -9,18 +9,19 @@ const defaultProps = {
   canEdit: true,
   deleteEnabled: true,
   language: 'python',
+  onDeleteClick: jest.fn(),
   onLanguageChange: jest.fn(),
   onLockClick: jest.fn(),
-  onSaveClick: jest.fn(),
-  onSaveAsClick: jest.fn(),
-  onDeleteClick: jest.fn(),
-  onTitleChange: jest.fn(),
   onOrgChanged: jest.fn(),
+  onSaveAsClick: jest.fn(),
+  onSaveClick: jest.fn(),
+  onThemeChange: jest.fn(),
+  onTitleChange: jest.fn(),
+  orgs: ['galactic-federation'],
   readOnly: false,
   saveEnabled: true,
-  title: '',
-  orgs: ['galactic-federation'],
   selectedOrg: 'galactic-federation',
+  title: '',
 };
 
 describe('<SnippetAreaToolbar />', () => {
@@ -134,6 +135,34 @@ describe('<SnippetAreaToolbar />', () => {
         />,
       );
       expect(wrapper.find('LanguageSelector').prop('disabled')).toBe(readOnly);
+    });
+  });
+
+  describe('prop: onThemeChange', () => {
+    it('is forwarded to the EditorMenu', () => {
+      const onChange = () => {};
+      const wrapper = shallowWithContext(
+        <SnippetAreaToolbar
+          {...defaultProps}
+          onThemeChange={onChange}
+        />,
+      );
+      const editorMenu = wrapper.find('EditorMenu');
+      expect(editorMenu.prop('onChange')).toEqual(onChange);
+    });
+  });
+
+  describe('prop: codeMirrorTheme', () => {
+    it('is forwarded to the EditorMenu', () => {
+      const codeMirrorTheme = 'monokai';
+      const wrapper = shallowWithContext(
+        <SnippetAreaToolbar
+          {...defaultProps}
+          codeMirrorTheme={codeMirrorTheme}
+        />,
+      );
+      const editorMenu = wrapper.find('EditorMenu');
+      expect(editorMenu.prop('codeMirrorTheme')).toEqual(codeMirrorTheme);
     });
   });
 });

--- a/__tests__/components/__snapshots__/SnippetAreaToolbar.test.jsx.snap
+++ b/__tests__/components/__snapshots__/SnippetAreaToolbar.test.jsx.snap
@@ -95,7 +95,8 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is no
           }
         } />
       <EditorMenu
-        codeMirrorTheme="codesplain" />
+        codeMirrorTheme="codesplain"
+        onChange={[Function]} />
     </div>
   </div>
 </div>
@@ -198,7 +199,8 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is re
           }
         } />
       <EditorMenu
-        codeMirrorTheme="codesplain" />
+        codeMirrorTheme="codesplain"
+        onChange={[Function]} />
     </div>
   </div>
 </div>

--- a/__tests__/components/__snapshots__/SnippetAreaToolbar.test.jsx.snap
+++ b/__tests__/components/__snapshots__/SnippetAreaToolbar.test.jsx.snap
@@ -94,6 +94,8 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is no
             "flex": "1 1 auto",
           }
         } />
+      <EditorMenu
+        codeMirrorTheme="codesplain" />
     </div>
   </div>
 </div>
@@ -195,6 +197,8 @@ exports[`<SnippetAreaToolbar /> snapshot tests matches snapshot of when it is re
             "flex": "1 1 auto",
           }
         } />
+      <EditorMenu
+        codeMirrorTheme="codesplain" />
     </div>
   </div>
 </div>

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -11,6 +11,7 @@ import {
   styleRegion,
 } from '../util/codemirror-utils';
 import '../util/codemirror-themes';
+import { getCodeMirrorTheme } from '../util/codemirror-theme-options';
 import CustomPropTypes from '../util/custom-prop-types';
 
 // Options for the CodeMirror instance that are shared by edit and annotation mddes
@@ -184,6 +185,7 @@ class Editor extends React.Component {
 
   render() {
     const {
+      codeMirrorTheme,
       language,
       onChange,
       readOnly,
@@ -193,6 +195,7 @@ class Editor extends React.Component {
     const codeMirrorOptions = {
       mode: getCodeMirrorMode(language),
       ...(readOnly ? annotationModeOptions : editModeOptions),
+      theme: getCodeMirrorTheme(codeMirrorTheme),
     };
 
     return (
@@ -207,6 +210,7 @@ class Editor extends React.Component {
 }
 
 Editor.propTypes = {
+  codeMirrorTheme: PropTypes.string,
   errors: CustomPropTypes.errors,
   filters: CustomPropTypes.filters.isRequired,
   language: PropTypes.string.isRequired,
@@ -219,6 +223,7 @@ Editor.propTypes = {
 };
 
 Editor.defaultProps = {
+  codeMirrorTheme: 'codesplain',
   openLine: -1,
   errors: [],
 };

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import CodeMirror from 'react-codemirror';
 import isEqual from 'lodash/isEqual';
-import 'codemirror/lib/codemirror.css';
 import 'codemirror/mode/python/python';
 
 import {
@@ -11,8 +10,8 @@ import {
   styleAll,
   styleRegion,
 } from '../util/codemirror-utils';
+import '../util/codemirror-themes';
 import CustomPropTypes from '../util/custom-prop-types';
-import '../styles/codesplain.css';
 
 // Options for the CodeMirror instance that are shared by edit and annotation mddes
 const baseCodeMirrorOptions = {
@@ -208,6 +207,7 @@ class Editor extends React.Component {
 }
 
 Editor.propTypes = {
+  errors: CustomPropTypes.errors,
   filters: CustomPropTypes.filters.isRequired,
   language: PropTypes.string.isRequired,
   markedLines: PropTypes.arrayOf(PropTypes.number).isRequired,
@@ -216,7 +216,6 @@ Editor.propTypes = {
   openLine: PropTypes.number,
   readOnly: PropTypes.bool.isRequired,
   value: PropTypes.string.isRequired,
-  errors: CustomPropTypes.errors,
 };
 
 Editor.defaultProps = {

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -224,8 +224,8 @@ Editor.propTypes = {
 
 Editor.defaultProps = {
   codeMirrorTheme: 'codesplain',
-  openLine: -1,
   errors: [],
+  openLine: -1,
 };
 
 export default Editor;

--- a/src/components/SnippetAreaToolbar.jsx
+++ b/src/components/SnippetAreaToolbar.jsx
@@ -48,6 +48,7 @@ const SnippetAreaToolbar = (props) => {
     author,
     avatarUrl,
     canEdit,
+    codeMirrorTheme,
     deleteEnabled,
     language,
     onDeleteClick,
@@ -56,13 +57,12 @@ const SnippetAreaToolbar = (props) => {
     onOrgChanged,
     onSaveAsClick,
     onSaveClick,
+    onThemeChange,
     onTitleChange,
     orgs,
     readOnly,
     saveEnabled,
     selectedOrg,
-    onThemeChange,
-    codeMirrorTheme,
     title,
   } = props;
 
@@ -124,6 +124,7 @@ SnippetAreaToolbar.propTypes = {
   author: PropTypes.string,
   avatarUrl: PropTypes.string,
   canEdit: PropTypes.bool.isRequired,
+  codeMirrorTheme: PropTypes.string,
   deleteEnabled: PropTypes.bool.isRequired,
   language: PropTypes.string.isRequired,
   onDeleteClick: PropTypes.func.isRequired,
@@ -132,6 +133,7 @@ SnippetAreaToolbar.propTypes = {
   onOrgChanged: PropTypes.func.isRequired,
   onSaveAsClick: PropTypes.func.isRequired,
   onSaveClick: PropTypes.func.isRequired,
+  onThemeChange: PropTypes.func.isRequired,
   onTitleChange: PropTypes.func.isRequired,
   orgs: CustomPropTypes.orgs.isRequired,
   readOnly: PropTypes.bool.isRequired,
@@ -143,6 +145,7 @@ SnippetAreaToolbar.propTypes = {
 SnippetAreaToolbar.defaultProps = {
   author: '',
   avatarUrl: '',
+  codeMirrorTheme: 'codesplain',
   selectedOrg: '',
 };
 

--- a/src/components/SnippetAreaToolbar.jsx
+++ b/src/components/SnippetAreaToolbar.jsx
@@ -8,6 +8,7 @@ import LanguageSelector from './LanguageSelector';
 import LockButton from './buttons/LockButton';
 import DeleteButton from './buttons/DeleteButton';
 import SaveMenu from './menus/SaveMenu';
+import EditorMenu from './menus/EditorMenu';
 import CustomPropTypes from '../util/custom-prop-types';
 
 const styles = {
@@ -60,6 +61,8 @@ const SnippetAreaToolbar = (props) => {
     readOnly,
     saveEnabled,
     selectedOrg,
+    onThemeChange,
+    codeMirrorTheme,
     title,
   } = props;
 
@@ -106,6 +109,10 @@ const SnippetAreaToolbar = (props) => {
             style={styles.button}
             isEnabled={deleteEnabled}
             onClick={onDeleteClick}
+          />
+          <EditorMenu
+            codeMirrorTheme={codeMirrorTheme}
+            onChange={onThemeChange}
           />
         </div>
       </div>

--- a/src/components/menus/EditorMenu.jsx
+++ b/src/components/menus/EditorMenu.jsx
@@ -4,7 +4,7 @@ import {
   IconMenu,
   MenuItem,
 } from 'material-ui';
-import SettingsIcon from 'material-ui/svg-icons/action/settings';
+import PaletteIcon from 'material-ui/svg-icons/image/palette';
 
 import codeMirrorThemeOptions from '../../util/codemirror-theme-options';
 
@@ -25,7 +25,7 @@ const EditorMenu = (props) => {
   } = props;
   return (
     <IconMenu
-      iconButtonElement={<IconButton><SettingsIcon /></IconButton>}
+      iconButtonElement={<IconButton><PaletteIcon /></IconButton>}
       onChange={onChange}
       value={codeMirrorTheme}
     >

--- a/src/components/menus/EditorMenu.jsx
+++ b/src/components/menus/EditorMenu.jsx
@@ -1,0 +1,50 @@
+import React, { PropTypes } from 'react';
+import {
+  IconButton,
+  IconMenu,
+  MenuItem,
+} from 'material-ui';
+import SettingsIcon from 'material-ui/svg-icons/action/settings';
+
+import codeMirrorThemeOptions from '../../util/codemirror-theme-options';
+
+const makeEditorMenuItems = () => (
+  codeMirrorThemeOptions.map(([displayName, value]) => (
+    <MenuItem
+      key={value}
+      primaryText={displayName}
+      value={value}
+    />
+  ))
+);
+
+const EditorMenu = (props) => {
+  const {
+    codeMirrorTheme,
+    onChange,
+  } = props;
+  return (
+    <IconMenu
+      iconButtonElement={<IconButton><SettingsIcon /></IconButton>}
+      onChange={onChange}
+      value={codeMirrorTheme}
+    >
+      <MenuItem
+        primaryText="Codesplain"
+        value="codesplain"
+      />
+      {makeEditorMenuItems()}
+    </IconMenu>
+  );
+};
+
+EditorMenu.propTypes = {
+  codeMirrorTheme: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+};
+
+EditorMenu.defaultProps = {
+  codeMirrorTheme: 'codesplain',
+};
+
+export default EditorMenu;

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -296,6 +296,7 @@ export class SnippetArea extends React.Component {
             author={author}
             avatarUrl={avatarUrl}
             canEdit={canEdit}
+            codeMirrorTheme={codeMirrorTheme}
             deleteEnabled={deleteEnabled}
             language={snippetLanguage}
             onDeleteClick={this.showDeleteModal}
@@ -304,14 +305,13 @@ export class SnippetArea extends React.Component {
             onOrgChanged={this.handleOrgChanged}
             onSaveAsClick={this.handleSaveAs}
             onSaveClick={this.handleSave}
+            onThemeChange={this.handleThemeChange}
             onTitleChange={this.handleTitleChanged}
             orgs={orgs}
             readOnly={readOnly}
             saveEnabled={Boolean(username)}
             selectedOrg={selectedOrg}
             title={snippetTitle}
-            onThemeChange={this.handleThemeChange}
-            codeMirrorTheme={codeMirrorTheme}
           />
           <ConfirmationDialog
             accept={this.handleToggleReadOnly}
@@ -329,6 +329,7 @@ export class SnippetArea extends React.Component {
           />
           <Editor
             AST={AST}
+            codeMirrorTheme={codeMirrorTheme}
             errors={errors}
             filters={filters}
             language={snippetLanguage}
@@ -338,7 +339,6 @@ export class SnippetArea extends React.Component {
             openLine={openLine}
             readOnly={readOnly}
             value={snippet}
-            codeMirrorTheme={codeMirrorTheme}
           />
         </CardText>
       </Card>

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -6,6 +6,7 @@ import {
 } from 'material-ui';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
+import cookie from 'react-cookie';
 
 import { openAnnotationPanel } from '../actions/annotation';
 import {
@@ -64,11 +65,12 @@ const debouncedParseSnippetDispatch = debounce(dispatchParseSnippet, 400);
 export class SnippetArea extends React.Component {
   constructor(props) {
     super(props);
+    const savedTheme = cookie.load('theme');
     this.state = {
       lockDialogOpen: false,
       deleteDialogOpen: false,
       avatarUrl: '',
-      codeMirrorTheme: 'codesplain',
+      codeMirrorTheme: savedTheme || 'codesplain',
     };
 
     this.handleCloseModal = this.handleCloseModal.bind(this);
@@ -89,6 +91,10 @@ export class SnippetArea extends React.Component {
   componentDidMount() {
     const { dispatch, snippetLanguage } = this.props;
     dispatch(loadParser(snippetLanguage));
+
+    if (cookie.load('theme') === undefined) {
+      cookie.save('theme', this.state.codeMirrorTheme, { path: '/' });
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -171,6 +177,7 @@ export class SnippetArea extends React.Component {
 
   handleThemeChange(_, codeMirrorTheme) {
     this.setState({ codeMirrorTheme });
+    cookie.save('theme', codeMirrorTheme, { path: '/' });
   }
 
   handleSave() {

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -68,6 +68,7 @@ export class SnippetArea extends React.Component {
       lockDialogOpen: false,
       deleteDialogOpen: false,
       avatarUrl: '',
+      codeMirrorTheme: 'codesplain',
     };
 
     this.handleCloseModal = this.handleCloseModal.bind(this);
@@ -76,10 +77,10 @@ export class SnippetArea extends React.Component {
     this.handleLanguageChanged = this.handleLanguageChanged.bind(this);
     this.handleLock = this.handleLock.bind(this);
     this.handleOrgChanged = this.handleOrgChanged.bind(this);
-    this.handleOrgChanged = this.handleOrgChanged.bind(this);
     this.handleSave = this.handleSave.bind(this);
     this.handleSaveAs = this.handleSaveAs.bind(this);
     this.handleSnippetChanged = this.handleSnippetChanged.bind(this);
+    this.handleThemeChange = this.handleThemeChange.bind(this);
     this.handleTitleChanged = this.handleTitleChanged.bind(this);
     this.handleToggleReadOnly = this.handleToggleReadOnly.bind(this);
     this.showDeleteModal = this.showDeleteModal.bind(this);
@@ -166,6 +167,10 @@ export class SnippetArea extends React.Component {
       lockDialogOpen: false,
       deleteDialogOpen: false,
     });
+  }
+
+  handleThemeChange(_, codeMirrorTheme) {
+    this.setState({ codeMirrorTheme });
   }
 
   handleSave() {
@@ -275,7 +280,7 @@ export class SnippetArea extends React.Component {
       snippetTitle,
       username,
     } = this.props;
-    const { avatarUrl } = this.state;
+    const { avatarUrl, codeMirrorTheme } = this.state;
     const markedLines = Object.keys(annotations).map(Number);
     // Delete button is enabled only when user is logged in, owns snippet,
     // and is not viewing a new snippet
@@ -305,6 +310,8 @@ export class SnippetArea extends React.Component {
             saveEnabled={Boolean(username)}
             selectedOrg={selectedOrg}
             title={snippetTitle}
+            onThemeChange={this.handleThemeChange}
+            codeMirrorTheme={codeMirrorTheme}
           />
           <ConfirmationDialog
             accept={this.handleToggleReadOnly}
@@ -331,6 +338,7 @@ export class SnippetArea extends React.Component {
             openLine={openLine}
             readOnly={readOnly}
             value={snippet}
+            codeMirrorTheme={codeMirrorTheme}
           />
         </CardText>
       </Card>

--- a/src/styles/codesplain.css
+++ b/src/styles/codesplain.css
@@ -14,12 +14,12 @@ body {
   height: inherit;
 }
 
-.cm-s-codesplain {
+.CodeMirror {
   flex: 1 1 auto;
   height: 100%;
 }
 
-.cm-s-codesplain span {
+.CodeMirror span {
   font-size: 105%;
   line-height: 130%;
   padding-top: 2px;

--- a/src/util/codemirror-theme-options.js
+++ b/src/util/codemirror-theme-options.js
@@ -1,0 +1,65 @@
+/* Schema for a theme:
+ * [ ${Display name}, ${menuItem value} ]
+ */
+export default [
+  ['3024 Day', '3024-day'],
+  ['3024 Night', '3024-night'],
+  ['ABCDEF', 'abcdef'],
+  ['Ambiance', 'ambiance'],
+  ['Base 16 Dark', 'base16-dark'],
+  ['Base 16 Light', 'base16-light'],
+  ['Bespin', 'bespin'],
+  ['Blackboard', 'blackboard'],
+  ['Cobalt', 'cobalt'],
+  ['Colorforth', 'colorforth'],
+  ['Dracula', 'dracula'],
+  ['Duotone Dark', 'duotone-dark'],
+  ['Duotone Light', 'duotone-light'],
+  ['Eclipse', 'eclipse'],
+  ['Elegant', 'elegant'],
+  ['Erlang Dark', 'erlang-dark'],
+  ['Hopscotch', 'hopscotch'],
+  ['Icecoder', 'icecoder'],
+  ['Isotope', 'isotope'],
+  ['Lesser Dark', 'lesser-dark'],
+  ['Liquibyte', 'liquibyte'],
+  ['Material', 'material'],
+  ['Mbo', 'mbo'],
+  ['MDN-like', 'mdn-like'],
+  ['Midnight', 'midnight'],
+  ['Monokai', 'monokai'],
+  ['Neat', 'neat'],
+  ['Neo', 'neo'],
+  ['Night', 'night'],
+  ['Panda Syntax', 'panda-syntax'],
+  ['Paraiso Dark', 'paraiso-dark'],
+  ['Paraiso Light', 'paraiso-light'],
+  ['Pastel On Dark', 'pastel-on-dark'],
+  ['Railscasts', 'railscasts'],
+  ['Rubyblue', 'rubyblue'],
+  ['Seti', 'seti'],
+  ['Solarized Dark', 'solarized-dark'],
+  ['Solarized Light', 'solarized-light'],
+  ['The Matrix', 'the-matrix'],
+  ['Tomorrow Night Bright', 'tomorrow-night-bright'],
+  ['Tomorrow Night Eighties', 'tomorrow-night-eighties'],
+  ['TTCN', 'ttcn'],
+  ['Twilight', 'twilight'],
+  ['Vibrant Ink', 'vibrant-ink'],
+  ['XQ Dark', 'xq-dark'],
+  ['XQ Light', 'xq-light'],
+  ['Yeti', 'yeti'],
+  ['Zenburn', 'zenburn'],
+];
+
+const codeMirrorThemes = {
+  'solarized-dark': 'solarized dark',
+  'solarized-light': 'solarized light',
+};
+
+export const getCodeMirrorTheme = (theme) => {
+  if (codeMirrorThemes[theme] !== undefined) {
+    return codeMirrorThemes[theme];
+  }
+  return theme;
+};

--- a/src/util/codemirror-themes.js
+++ b/src/util/codemirror-themes.js
@@ -1,0 +1,54 @@
+// Default codemirror theme
+import 'codemirror/lib/codemirror.css';
+// Included themes
+import 'codemirror/theme/3024-day.css';
+import 'codemirror/theme/3024-night.css';
+import 'codemirror/theme/abcdef.css';
+import 'codemirror/theme/ambiance-mobile.css';
+import 'codemirror/theme/ambiance.css';
+import 'codemirror/theme/base16-dark.css';
+import 'codemirror/theme/base16-light.css';
+import 'codemirror/theme/bespin.css';
+import 'codemirror/theme/blackboard.css';
+import 'codemirror/theme/cobalt.css';
+import 'codemirror/theme/colorforth.css';
+import 'codemirror/theme/dracula.css';
+import 'codemirror/theme/duotone-dark.css';
+import 'codemirror/theme/duotone-light.css';
+import 'codemirror/theme/eclipse.css';
+import 'codemirror/theme/elegant.css';
+import 'codemirror/theme/erlang-dark.css';
+import 'codemirror/theme/hopscotch.css';
+import 'codemirror/theme/icecoder.css';
+import 'codemirror/theme/isotope.css';
+import 'codemirror/theme/lesser-dark.css';
+import 'codemirror/theme/liquibyte.css';
+import 'codemirror/theme/material.css';
+import 'codemirror/theme/mbo.css';
+import 'codemirror/theme/mdn-like.css';
+import 'codemirror/theme/midnight.css';
+import 'codemirror/theme/monokai.css';
+import 'codemirror/theme/neat.css';
+import 'codemirror/theme/neo.css';
+import 'codemirror/theme/night.css';
+import 'codemirror/theme/panda-syntax.css';
+import 'codemirror/theme/paraiso-dark.css';
+import 'codemirror/theme/paraiso-light.css';
+import 'codemirror/theme/pastel-on-dark.css';
+import 'codemirror/theme/railscasts.css';
+import 'codemirror/theme/rubyblue.css';
+import 'codemirror/theme/seti.css';
+import 'codemirror/theme/solarized.css';
+import 'codemirror/theme/the-matrix.css';
+import 'codemirror/theme/tomorrow-night-bright.css';
+import 'codemirror/theme/tomorrow-night-eighties.css';
+import 'codemirror/theme/ttcn.css';
+import 'codemirror/theme/twilight.css';
+import 'codemirror/theme/vibrant-ink.css';
+import 'codemirror/theme/xq-dark.css';
+import 'codemirror/theme/xq-light.css';
+import 'codemirror/theme/yeti.css';
+import 'codemirror/theme/zenburn.css';
+
+// Codesplain-specific theme
+import '../styles/codesplain.css';

--- a/src/util/codemirror-themes.js
+++ b/src/util/codemirror-themes.js
@@ -4,7 +4,6 @@ import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/3024-day.css';
 import 'codemirror/theme/3024-night.css';
 import 'codemirror/theme/abcdef.css';
-import 'codemirror/theme/ambiance-mobile.css';
 import 'codemirror/theme/ambiance.css';
 import 'codemirror/theme/base16-dark.css';
 import 'codemirror/theme/base16-light.css';

--- a/src/util/codemirror-utils.js
+++ b/src/util/codemirror-utils.js
@@ -33,7 +33,7 @@ Recursive function for highlighting code in a CodeMirror. highlight() is an
 exported wrapper func for this, and starts the recursion.
 */
 export function highlightNode(codeMirror, node, filters, parentColor) {
-  let color = parentColor;
+  let backgroundColor = parentColor;
   // Node's type is the last element of the node's tags property,
   // if AST was made with tagging parser. Otherwise, if it was made with
   // the legacy parser, it is the type property.
@@ -48,21 +48,23 @@ export function highlightNode(codeMirror, node, filters, parentColor) {
     const rule = rules[type];
     // Use this node's color if it has one
     if (rule.color) {
-      color = rule.color;
+      backgroundColor = rule.color;
     }
 
     // If this token's filter is not selected
     if (!filters[type] || !filters[type].selected) {
-      color = parentColor;
+      backgroundColor = parentColor;
     }
 
+    const fontColor = backgroundColor !== 'transparent' ? 'black' : '';
+
     // Apply the background color CSS to this token
-    styleRegion(codeMirror, node.begin, node.end, `background-color: ${color};`);
+    styleRegion(codeMirror, node.begin, node.end, `background-color: ${backgroundColor}; color: ${fontColor}`);
   }
 
   // Highlight all children of this token
   node.children.forEach((child) => {
-    if (isObject(child)) { highlightNode(codeMirror, child, filters, color); }
+    if (isObject(child)) { highlightNode(codeMirror, child, filters, backgroundColor); }
   });
 }
 


### PR DESCRIPTION
## Description
What the title says. Your selected theme will be saved in cookies, so if you select the `monokai` theme and then exit Codesplain, you can expect the theme to be selected when you return

## Motivation and Context
Fixes #468 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other:
