### PR TITLE
Add check when loading new parser for differing filters

### DIFF
--- a/src/util/rules.js
+++ b/src/util/rules.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import isEqual from 'lodash/isEqual';
 import last from 'lodash/last';
 import {
   setRules,
@@ -69,7 +70,9 @@ const onStateChange = async () => {
     // the filters panel doesn't display any rules ignored
     // within those new mappings.
     const newState = removeDeprecatedFiltersFromState(state.app);
-    store.dispatch(restoreState(newState));
+    if (!isEqual(newState.filters, state.app.filters)) {
+      store.dispatch(restoreState(newState));
+    }
   }
   currentLanguage = newLanguage;
 };


### PR DESCRIPTION
## Description
When loading a new parser, checks if the new filters returned from `removeDeprecatedFiltersFromState` differs from the old filters; if it hasn't changed, then `restoreState` will not be dispatched

## Motivation and Context
Minor optimization

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Mobile:
- [ ] Other:
