### PR TITLE
Resize CodeMirror line numbers gutter

### DIFF
--- a/src/styles/codesplain.css
+++ b/src/styles/codesplain.css
@@ -55,6 +55,10 @@ body {
   padding-top: 3px;
 }
 
+.CodeMirror-linenumbers {
+  width: 40px;
+}
+
 .section-title {
   margin-bottom: 0;
 }


### PR DESCRIPTION
## Description
Widens the line numbers gutter to accommodate for line numbers in the tens or hundreds

## Motivation and Context
Fixes #484 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
<img width="899" alt="screen shot 2017-05-25 at 10 52 08 am" src="https://cloud.githubusercontent.com/assets/10211603/26458402/c74b538c-4138-11e7-9273-c7f241e79b3d.png">
<img width="905" alt="screen shot 2017-05-25 at 10 51 59 am" src="https://cloud.githubusercontent.com/assets/10211603/26458403/c7560232-4138-11e7-9897-349c95e09d48.png">
