### PR TITLE
Corrected timestamp prop type to be string

### DIFF
--- a/src/util/custom-prop-types.js
+++ b/src/util/custom-prop-types.js
@@ -51,7 +51,7 @@ const orderedSnippets = PropTypes.arrayOf(
   PropTypes.shape({
     snippetTitle: PropTypes.string,
     role: PropTypes.string,
-    lastEdited: PropTypes.number,
+    lastEdited: PropTypes.string,
     language: PropTypes.string,
   }),
 );


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Corrects the prop types of the timestamp
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
