### PR TITLE
Marker

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -39,6 +39,7 @@ const annotationModeOptions = {
 const makeMarker = () => {
   const marker = document.createElement('div');
   marker.style.color = 'teal';
+  marker.style['font-size'] = '20px';
   marker.innerHTML = '✎';
   return marker;
 };

--- a/src/styles/codesplain.css
+++ b/src/styles/codesplain.css
@@ -52,11 +52,11 @@ body {
 }
 
 .CodeMirror-linenumber {
-  padding-top: 3px;
+  padding-top: 5px;
 }
 
 .CodeMirror-linenumbers {
-  width: 40px;
+  width: 50px;
 }
 
 .section-title {


### PR DESCRIPTION
## Description
Increases the size of the annotation marker. To accommodate this, the gutter width and the padding-top of the line numbers was also increased

## Motivation and Context
Fixes #550

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
Chrome:
![screen shot 2017-05-25 at 2 23 07 pm](https://cloud.githubusercontent.com/assets/10211603/26466899/0e808f16-4156-11e7-91fa-dcb530de26a8.png)
FF:
![screen shot 2017-05-25 at 2 22 45 pm](https://cloud.githubusercontent.com/assets/10211603/26466900/0e80fcf8-4156-11e7-8ec3-4eab344167ce.png)
Safari:
![screen shot 2017-05-25 at 2 22 33 pm](https://cloud.githubusercontent.com/assets/10211603/26466898/0e79f548-4156-11e7-9d04-0f55d38d5a03.png)
