### PR TITLE
Decrease width for title and role sections in org snippet list

### DIFF
--- a/__tests__/components/__snapshots__/SnippetList.test.jsx.snap
+++ b/__tests__/components/__snapshots__/SnippetList.test.jsx.snap
@@ -57,7 +57,7 @@ exports[`<SnippetList /> snapshot tests matches when snippets are passed 1`] = `
                         <td
                             style={
                                 Object {
-                                    "width": "13em",
+                                    "width": "10em",
                                   }
                             }>
                             bar
@@ -113,7 +113,7 @@ exports[`<SnippetList /> snapshot tests matches when snippets are passed 1`] = `
                         <td
                             style={
                                 Object {
-                                    "width": "13em",
+                                    "width": "10em",
                                   }
                             }>
                             qux

--- a/src/components/menus/SnippetMenuItem.jsx
+++ b/src/components/menus/SnippetMenuItem.jsx
@@ -8,10 +8,10 @@ const styles = {
     width: '100%',
   },
   title: {
-    width: '13em',
+    width: '10em',
   },
   role: {
-    width: '17em',
+    width: '10em',
   },
   language: {
     float: 'left',


### PR DESCRIPTION
## Description
Fixes the funky layout for items in the Organization snippet lists

## Motivation and Context
Because it's necessary

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
Before:
<img width="563" alt="screen shot 2017-05-26 at 10 17 47 am" src="https://cloud.githubusercontent.com/assets/10211603/26500717/a2dd03fa-41fc-11e7-9b33-1fedc1bd66e5.png">

After:
<img width="564" alt="screen shot 2017-05-26 at 10 18 00 am" src="https://cloud.githubusercontent.com/assets/10211603/26500716/a0b9b640-41fc-11e7-8611-89cf77d5578c.png">
