### PR TITLE
change search and snippet menu title length

### DIFF
--- a/__tests__/components/__snapshots__/SnippetList.test.jsx.snap
+++ b/__tests__/components/__snapshots__/SnippetList.test.jsx.snap
@@ -57,7 +57,7 @@ exports[`<SnippetList /> snapshot tests matches when snippets are passed 1`] = `
                         <td
                             style={
                                 Object {
-                                    "width": "10em",
+                                    "width": "20em",
                                   }
                             }>
                             bar
@@ -113,7 +113,7 @@ exports[`<SnippetList /> snapshot tests matches when snippets are passed 1`] = `
                         <td
                             style={
                                 Object {
-                                    "width": "10em",
+                                    "width": "20em",
                                   }
                             }>
                             qux

--- a/src/components/menus/SnippetMenuItem.jsx
+++ b/src/components/menus/SnippetMenuItem.jsx
@@ -8,7 +8,7 @@ const styles = {
     width: '100%',
   },
   title: {
-    width: '10em',
+    width: '20em',
   },
   role: {
     width: '10em',
@@ -35,11 +35,11 @@ const SnippetMenuItem = ({ snippetTitle, language, lastEdited, role }) => (
   <table style={styles.menuItem}>
     <tbody>
       <tr>
-        <td style={styles.title}>{makeDisplayTitle(snippetTitle, 10)}</td>
+        <td style={styles.title}>{makeDisplayTitle(snippetTitle, 24)}</td>
         {
-        role ?
-          <td style={styles.role}>
-            {makeDisplayTitle(role, 14)}
+          role ?
+            <td style={styles.role}>
+              {makeDisplayTitle(role, 14)}
           </td>
         : null
       }


### PR DESCRIPTION
## Description
I couldn't read the title of my snippet, now i can read more of it




## Motivation and Context
Connects #541 
Snippet titles were being trimmed too much. I fixed that

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
#### Current
<img width="768" alt="screen shot 2017-05-26 at 11 23 59 am" src="https://cloud.githubusercontent.com/assets/12362348/26503315/d4e14dc6-4205-11e7-90d1-d6c34cafe8ec.png">

#### With change
<img width="747" alt="screen shot 2017-05-26 at 11 18 54 am" src="https://cloud.githubusercontent.com/assets/12362348/26503290/b73d51e8-4205-11e7-9e37-57dbd39b8d15.png">
<img width="774" alt="screen shot 2017-05-26 at 11 18 59 am" src="https://cloud.githubusercontent.com/assets/12362348/26503301/c28dbcc2-4205-11e7-889b-cb94a30f276e.png">
