### PR TITLE
Apply custom Material-UI theme to project

### DIFF
--- a/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationDisplay.test.jsx.snap
@@ -12,11 +12,16 @@ exports[`<AnnotationDisplay /> snapshots when an annotation after current one ex
       }
     }>
     <div>
-      <RaisedButton
+      <FlatButton
         disabled={false}
         fullWidth={false}
         label="Close"
         labelPosition="after"
+        labelStyle={Object {}}
+        onKeyboardFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
         onTouchTap={[Function]}
         primary={false}
         secondary={true}
@@ -25,11 +30,16 @@ exports[`<AnnotationDisplay /> snapshots when an annotation after current one ex
             "marginRight": "0.2rem",
           }
         } />
-      <RaisedButton
+      <FlatButton
         disabled={false}
         fullWidth={false}
         label="Edit"
         labelPosition="after"
+        labelStyle={Object {}}
+        onKeyboardFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
         onTouchTap={[Function]}
         primary={true}
         secondary={false} />
@@ -52,11 +62,16 @@ exports[`<AnnotationDisplay /> snapshots when an annotation before current one e
       }
     }>
     <div>
-      <RaisedButton
+      <FlatButton
         disabled={false}
         fullWidth={false}
         label="Close"
         labelPosition="after"
+        labelStyle={Object {}}
+        onKeyboardFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
         onTouchTap={[Function]}
         primary={false}
         secondary={true}
@@ -65,11 +80,16 @@ exports[`<AnnotationDisplay /> snapshots when an annotation before current one e
             "marginRight": "0.2rem",
           }
         } />
-      <RaisedButton
+      <FlatButton
         disabled={false}
         fullWidth={false}
         label="Edit"
         labelPosition="after"
+        labelStyle={Object {}}
+        onKeyboardFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
         onTouchTap={[Function]}
         primary={true}
         secondary={false} />
@@ -92,11 +112,16 @@ exports[`<AnnotationDisplay /> snapshots when annotation exists before/after cur
       }
     }>
     <div>
-      <RaisedButton
+      <FlatButton
         disabled={false}
         fullWidth={false}
         label="Close"
         labelPosition="after"
+        labelStyle={Object {}}
+        onKeyboardFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
         onTouchTap={[Function]}
         primary={false}
         secondary={true}
@@ -105,11 +130,16 @@ exports[`<AnnotationDisplay /> snapshots when annotation exists before/after cur
             "marginRight": "0.2rem",
           }
         } />
-      <RaisedButton
+      <FlatButton
         disabled={false}
         fullWidth={false}
         label="Edit"
         labelPosition="after"
+        labelStyle={Object {}}
+        onKeyboardFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
         onTouchTap={[Function]}
         primary={true}
         secondary={false} />
@@ -132,11 +162,16 @@ exports[`<AnnotationDisplay /> snapshots when no annotations before/after curren
       }
     }>
     <div>
-      <RaisedButton
+      <FlatButton
         disabled={false}
         fullWidth={false}
         label="Close"
         labelPosition="after"
+        labelStyle={Object {}}
+        onKeyboardFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
         onTouchTap={[Function]}
         primary={false}
         secondary={true}
@@ -145,11 +180,16 @@ exports[`<AnnotationDisplay /> snapshots when no annotations before/after curren
             "marginRight": "0.2rem",
           }
         } />
-      <RaisedButton
+      <FlatButton
         disabled={false}
         fullWidth={false}
         label="Edit"
         labelPosition="after"
+        labelStyle={Object {}}
+        onKeyboardFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
         onTouchTap={[Function]}
         primary={true}
         secondary={false} />

--- a/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
+++ b/__tests__/components/__snapshots__/AnnotationEditor.test.jsx.snap
@@ -41,11 +41,16 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
         "marginTop": "0.5rem",
       }
     }>
-    <RaisedButton
+    <FlatButton
       disabled={false}
       fullWidth={false}
       label="Cancel"
       labelPosition="after"
+      labelStyle={Object {}}
+      onKeyboardFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={[Function]}
       onTouchTap={[Function]}
       primary={false}
       secondary={true}
@@ -54,11 +59,16 @@ exports[`<AnnotationEditor /> matches snapshot 1`] = `
           "flex": "1 1",
         }
       } />
-    <RaisedButton
+    <FlatButton
       disabled={true}
       fullWidth={false}
       label="Save"
       labelPosition="after"
+      labelStyle={Object {}}
+      onKeyboardFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={[Function]}
       onTouchTap={[Function]}
       primary={true}
       secondary={false}

--- a/__tests__/components/__snapshots__/SaveMenu.test.jsx.snap
+++ b/__tests__/components/__snapshots__/SaveMenu.test.jsx.snap
@@ -106,7 +106,7 @@ exports[`<SaveMenu /> snapshot tests matches default snapshot 1`] = `
           onTouchStart={[Function]}
           onTouchTap={[Function]}
           primary={false}
-          secondary={false} />
+          secondary={true} />
         <FlatButton
           disabled={false}
           fullWidth={false}
@@ -259,7 +259,7 @@ exports[`<SaveMenu /> snapshot tests matches snapshot when saving is not enabled
           onTouchStart={[Function]}
           onTouchTap={[Function]}
           primary={false}
-          secondary={false} />
+          secondary={true} />
         <FlatButton
           disabled={false}
           fullWidth={false}
@@ -412,7 +412,7 @@ exports[`<SaveMenu /> snapshot tests matches snapshot when user cannot save 1`] 
           onTouchStart={[Function]}
           onTouchTap={[Function]}
           primary={false}
-          secondary={false} />
+          secondary={true} />
         <FlatButton
           disabled={false}
           fullWidth={false}

--- a/src/components/AnnotationDisplay.jsx
+++ b/src/components/AnnotationDisplay.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import RaisedButton from 'material-ui/RaisedButton';
+import FlatButton from 'material-ui/FlatButton';
 
 import MarkdownDisplayer from './MarkdownDisplayer';
 
@@ -33,13 +33,13 @@ const AnnotationDisplay = (props) => {
       <MarkdownDisplayer annotation={annotation} />
       <div style={styles.actionRow}>
         <div style={styles.actionButtons}>
-          <RaisedButton
+          <FlatButton
             label="Close"
             onTouchTap={closeAnnotation}
             secondary
             style={styles.cancelButton}
           />
-          <RaisedButton
+          <FlatButton
             label="Edit"
             onTouchTap={editAnnotation}
             primary

--- a/src/components/AnnotationEditor.jsx
+++ b/src/components/AnnotationEditor.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { Tab, Tabs } from 'material-ui/Tabs';
 import TextField from 'material-ui/TextField';
-import RaisedButton from 'material-ui/RaisedButton';
+import FlatButton from 'material-ui/FlatButton';
 
 import MarkdownDisplayer from './MarkdownDisplayer';
 import markdownLogo from '../../res/markdown-logo.svg';
@@ -49,10 +49,8 @@ class AnnotationEditor extends React.Component {
     this.saveAnnotation = this.saveAnnotation.bind(this);
   }
 
-  onAnnotationChange(ev, annotation) {
-    this.setState({
-      annotation,
-    });
+  onAnnotationChange(_, annotation) {
+    this.setState({ annotation });
   }
 
   clearAnnotation() {
@@ -92,13 +90,13 @@ class AnnotationEditor extends React.Component {
           </Tab>
         </Tabs>
         <div style={styles.bottomContainer}>
-          <RaisedButton
+          <FlatButton
             label="Cancel"
             onTouchTap={this.clearAnnotation}
             secondary
             style={styles.cancelButton}
           />
-          <RaisedButton
+          <FlatButton
             disabled={!annotation}
             label="Save"
             onTouchTap={this.saveAnnotation}

--- a/src/components/menus/SaveMenu.jsx
+++ b/src/components/menus/SaveMenu.jsx
@@ -94,6 +94,7 @@ class SaveMenu extends React.Component {
         actions={
           <span>
             <FlatButton
+              secondary
               label="Cancel"
               onTouchTap={() => this.setState({ showSaveAsDialog: false })}
             />

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { MuiThemeProvider } from 'material-ui/styles';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
@@ -19,6 +20,7 @@ import App from './components/App';
 import Auth from './components/Auth';
 import NotFoundView from './components/NotFoundView';
 import configureStore from './store/configureStore';
+import customMuiStyles from './styles/mui-styles';
 import { initRules } from './util/rules';
 
 // Needed for onTouchTap
@@ -36,7 +38,7 @@ history.listenBeforeUnload(() => {
 });
 
 ReactDOM.render(
-  <MuiThemeProvider>
+  <MuiThemeProvider muiTheme={getMuiTheme(customMuiStyles)}>
     <Provider store={store}>
       <Router history={history}>
         <Route path="/auth" component={Auth} />

--- a/src/styles/mui-styles.js
+++ b/src/styles/mui-styles.js
@@ -1,14 +1,20 @@
 export default {
+  flatButton: {
+    primaryTextColor: '#00e6e6',
+    secondaryTextColor: '#f44336',
+  },
   inkBar: {
     backgroundColor: '#00e6e6',
   },
+  menuItem: {
+    selectedTextColor: '#00e6e6',
+  },
   tabs: {
     backgroundColor: ' #333333',
-    textColor: 'white',
-    selectedTextColor: 'white',
+    textColor: '#ffffff',
+    selectedTextColor: '#ffffff',
   },
-  flatButton: {
-    primaryTextColor: '#00e6e6',
-    secondaryTextColor: 'red',
+  textField: {
+    focusColor: '#00e6e6',
   },
 };

--- a/src/styles/mui-styles.js
+++ b/src/styles/mui-styles.js
@@ -1,0 +1,14 @@
+export default {
+  inkBar: {
+    backgroundColor: '#00e6e6',
+  },
+  tabs: {
+    backgroundColor: ' #333333',
+    textColor: 'white',
+    selectedTextColor: 'white',
+  },
+  flatButton: {
+    primaryTextColor: '#00e6e6',
+    secondaryTextColor: 'red',
+  },
+};


### PR DESCRIPTION
## Description
Adds custom theming to use our teal color as the primary color and red as the secondary color. This affects:
- `TextField`
- `MenuItem` (specifically the `LanguageSelector`)
- `FlatButton`
- `Tabs`

## Motivation and Context
Fixes #558 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
Check slack, or checkout this branch and compare the instance to dev