### PR TITLE
Refactor FilterAreaActions to have consistent spacing across all browsers

### DIFF
--- a/__tests__/components/__snapshots__/FilterAreaActions.test.jsx.snap
+++ b/__tests__/components/__snapshots__/FilterAreaActions.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`<FilterAreaActions /> matches snapshot of when the app is not in read-o
     Object {
       "display": "flex",
       "flexFlow": "row nowrap",
-      "justifyContent": "space-evenly",
+      "justifyContent": "space-around",
     }
   }>
   <FlatButton

--- a/src/components/FilterAreaActions.jsx
+++ b/src/components/FilterAreaActions.jsx
@@ -8,7 +8,7 @@ const styles = {
   cardActions: {
     display: 'flex',
     flexFlow: 'row nowrap',
-    justifyContent: 'space-evenly',
+    justifyContent: 'space-around',
   },
   label: {
     fontSize: '12px',


### PR DESCRIPTION
## Description
Sets the `justify-content` CSS property to `space-around` to make the spacing for the buttons consistent across all browsers

## Motivation and Context
Previously, we were setting the `justify-content` property to `space-evenly`, which is supported by Firefox, but not Chrome or Safari, so there would be an inconsistency in how the buttons are placed. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other:

## Screenshots (if appropriate):
### `space-evenly`:
- Safari:
<img width="502" alt="screen shot 2017-05-30 at 11 21 28 am" src="https://cloud.githubusercontent.com/assets/10211603/26593793/01e884ec-452b-11e7-829e-78d6132e1573.png">
- Chrome:
<img width="253" alt="screen shot 2017-05-30 at 11 21 51 am" src="https://cloud.githubusercontent.com/assets/10211603/26593806/0873dcd0-452b-11e7-8625-22d2470436f0.png">
- Firefox:
<img width="504" alt="screen shot 2017-05-30 at 11 22 14 am" src="https://cloud.githubusercontent.com/assets/10211603/26593813/10d7a640-452b-11e7-941c-55b832bd694f.png">

### `space-around`:
- Safari:
<img width="507" alt="screen shot 2017-05-30 at 11 21 21 am" src="https://cloud.githubusercontent.com/assets/10211603/26593861/28b4edfe-452b-11e7-8ce1-861db9565f54.png">
- Chrome:
<img width="254" alt="screen shot 2017-05-30 at 11 21 36 am" src="https://cloud.githubusercontent.com/assets/10211603/26593874/315993ce-452b-11e7-96da-b237f8ccba70.png">
- Firefox:
<img width="504" alt="screen shot 2017-05-30 at 11 22 21 am" src="https://cloud.githubusercontent.com/assets/10211603/26593882/35101a60-452b-11e7-8de9-61609bfa8053.png">

