### PR TITLE
[Editor] fix highlighting disappearing when updating CodeMirror

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -76,7 +76,7 @@ class Editor extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // List of props that need to be compared
+    // List of props that dont' need to be compared
     const omitted = [
       'onChange',
       'onGutterClick',


### PR DESCRIPTION
## Description
This PR ensures that highlighting in the CodeMirror instance does not vanish when updating the instance. It checks if the props that update the CodeMirror instance have changed and sets a state variable

## Motivation and Context
Fixes #564 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other: