### PR TITLE
Return to view mode after annotation save

### DIFF
--- a/src/containers/Annotations.jsx
+++ b/src/containers/Annotations.jsx
@@ -141,9 +141,7 @@ export class Annotations extends React.Component {
     // Save the snippet only if this snippet has already been saved.
     if (snippetKey) {
       dispatch(saveExisting())
-        .then(() => {
-          this.toggleEditState();
-        });
+        .then(() => this.setState({ isEditing: false }));
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
After the user saves an edited annotation, return to the view mode for that annotation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #569.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Mobile:
- [ ] Other: