### PR TITLE
Display avatar if not logged in

### DIFF
--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -90,6 +90,8 @@ export class SnippetArea extends React.Component {
 
     if (cookie.load('theme') === undefined) {
       cookie.save('theme', this.state.codeMirrorTheme, { path: '/' });
+    }
+    if (cookie.load('keymap') === undefined) {
       cookie.save('keymap', this.state.selectedKeymap, { path: '/' });
     }
   }

--- a/src/containers/SnippetArea.jsx
+++ b/src/containers/SnippetArea.jsx
@@ -102,21 +102,28 @@ export class SnippetArea extends React.Component {
       token,
     } = this.props;
 
-    if (!nextProps.author || !token) {
+    const {
+      author: nextAuthor,
+    } = nextProps;
+
+    if (!nextAuthor) {
       this.setState({ avatarUrl: '' });
       return;
+    } else if (!token) {
+      this.setState({ avatarUrl: `https://avatars.githubusercontent.com/${nextAuthor}` });
+      return;
     }
-    if (author !== nextProps.author) {
+    if (author !== nextAuthor) {
       // The URL to the user's avatar is already in the store, so if the snippet
       // is owned by the current user, then use the URL in the store instead
       // of pinging Github's API for it.
-      if (loggedInUser === nextProps.author) {
+      if (loggedInUser === nextAuthor) {
         this.setState({
           avatarUrl: loggedInUserAvatarUrl,
         });
         return;
       }
-      fetchUserAvatar(nextProps.author, token)
+      fetchUserAvatar(nextAuthor, token)
         .then(avatarUrl => this.setState({ avatarUrl }));
     }
   }


### PR DESCRIPTION
## Description
Sets the avatar URL for the author of a snippet even if the user isn't logged into Github (and thus cannot use the API).

## Motivation and Context
It's a bug

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Browsers
<!-- Which browsers have you tested this on? -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Mobile:
- [ ] Other:
